### PR TITLE
Sort input file list

### DIFF
--- a/create_shadertext.py
+++ b/create_shadertext.py
@@ -70,7 +70,7 @@ def create_shadertext(shaderdir, shaderdir2, outputheader, outputfile):
     for sdir in [shaderdir, shaderdir2]:
         for ext in ['gs', 'vs', 'fs', 'shared']:
             shaderfiles.update(map(os.path.basename,
-                glob.glob(os.path.join(sdir, '*.' + ext))))
+                sorted(glob.glob(os.path.join(sdir, '*.' + ext)))))
 
     varname = '_shader_cache_raw'
     outputheader.write('extern const char * %s[];\n' % varname)


### PR DESCRIPTION
so that /usr/lib64/python2.7/site-packages/pymol/_cmd.so in
openSUSE's python-pymol package builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.