### PR TITLE
Fixes to class comparisons and ordering for Python 3 compatibility

### DIFF
--- a/modules/chempy/__init__.py
+++ b/modules/chempy/__init__.py
@@ -16,11 +16,13 @@ from __future__ import print_function
 
 import os
 import copy
+import functools
 
 #
 # Basic chempy types
 #
 
+@functools.total_ordering
 class Atom(object):
 
     def __reduce__(self):
@@ -132,7 +134,27 @@ class Atom(object):
                 cmp(self.symbol, other.symbol) or \
                 cmp(self.name, other.name) or \
                 cmp(id(self), id(other))
-        
+
+    @staticmethod
+    def _order(obj):
+        return (
+            obj.segi,
+            obj.chain,
+            obj.resi_number,
+            obj.resi,
+            obj.resn,
+            obj.symbol,
+            obj.name,
+            id(obj),
+        )
+
+    def __gt__(self, other):
+        return Atom._order(self) > Atom._order(other)
+
+    def __eq__(self, other):
+        return Atom._order(self) == Atom._order(other)
+
+
 class Bond:
 
     order   = 1

--- a/modules/chempy/hetatm.py
+++ b/modules/chempy/hetatm.py
@@ -16,6 +16,7 @@
 #
 #
 
+import chempy.models
 from chempy.neighbor import Neighbor
 from chempy.models import Connected
 from chempy import Bond
@@ -35,7 +36,7 @@ def generate(model, topology= None, forcefield = None ):
 
 #---------------------------------------------------------------------------------
 def assign_types(model, topology = None, forcefield = None ):
-    if str(model.__class__) != 'chempy.models.Indexed':
+    if not isinstance(model, chempy.models.Indexed):
         raise ValueError('model is not an "Indexed" model object')
     nAtom = model.nAtom
     if nAtom:
@@ -67,7 +68,7 @@ def assign_types(model, topology = None, forcefield = None ):
 
 #---------------------------------------------------------------------------------
 def add_bonds(model, topology = None, forcefield = None ):
-    if str(model.__class__) != 'chempy.models.Indexed':
+    if not isinstance(model, chempy.models.Indexed):
         raise ValueError('model is not an "Indexed" model object')
     nAtom = model.nAtom
     if nAtom:
@@ -108,7 +109,7 @@ def add_bonds(model, topology = None, forcefield = None ):
                             
 #---------------------------------------------------------------------------------
 def add_hydrogens(model,topology=None,forcefield=None):  
-    if str(model.__class__) != 'chempy.models.Connected':
+    if not isinstance(model, chempy.models.Connected):
         raise ValueError('model is not a "Connected" model object')
     nAtom = model.nAtom
     if nAtom:

--- a/modules/chempy/place.py
+++ b/modules/chempy/place.py
@@ -21,6 +21,8 @@ from . import bond_amber
 
 from chempy.cpv import *
 from chempy import feedback
+import chempy.models
+
 
 TET_TAN = 1.41
 TRI_TAN = 1.732
@@ -51,7 +53,7 @@ def simple_unknowns(model,bondfield=bond_amber):
         print(" "+str(__name__)+": placing unknowns...")
     # this can be used to build hydrogens and would robably work for
     # acyclic carbons as well
-    if str(model.__class__) != 'chempy.models.Connected':
+    if not isinstance(model, chempy.models.Connected):
         raise ValueError('model is not a "Connected" model object')
     if model.nAtom:
         if not model.index:

--- a/modules/chempy/protein.py
+++ b/modules/chempy/protein.py
@@ -22,6 +22,7 @@ from . import bond_amber
 from . import protein_residues
 from . import protein_amber
 
+import chempy.models
 from chempy.neighbor import Neighbor
 from chempy.models import Connected
 from chempy import Bond,place,feedback
@@ -66,7 +67,7 @@ but does not add any bonds!
 '''
     if feedback['actions']:
         print(" "+str(__name__)+": assigning types...")
-    if str(model.__class__) != 'chempy.models.Indexed':
+    if not isinstance(model, chempy.models.Indexed):
         raise ValueError('model is not an "Indexed" model object')
     if model.nAtom:
         crd = model.get_coord_list()
@@ -164,7 +165,7 @@ add_bonds(model, forcefield = protein_amber, histidine = 'HIE' )
     '''
     if feedback['actions']:
         print(" "+str(__name__)+": assigning types and bonds...")
-    if str(model.__class__) != 'chempy.models.Indexed':
+    if not isinstance(model, chempy.models.Indexed):
         raise ValueError('model is not an "Indexed" model object')
     if model.nAtom:
         crd = model.get_coord_list()
@@ -283,7 +284,7 @@ def add_hydrogens(model,forcefield=protein_amber,skip_sort=None):
     # assumes no bonds between non-hetatms
     if feedback['actions']:
         print(" "+str(__name__)+": adding hydrogens...")
-    if str(model.__class__) != 'chempy.models.Connected':
+    if not isinstance(model, chempy.models.Connected):
         raise ValueError('model is not a "Connected" model object')
     if model.nAtom:
         if not model.index:

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -24,6 +24,7 @@ if __name__=='pymol.editing':
           boolean_sc,boolean_dict,safe_list_eval, is_sequence, \
           DEFAULT_ERROR, DEFAULT_SUCCESS, _raising, is_ok, is_error              
     from chempy import cpv
+    import pymol.wizard.dragging
     
     ref_action_dict = {
         'store'     : 1,
@@ -979,7 +980,7 @@ NOTES
                 wiz = _self.get_wizard()
                 if (wiz == None):
                     _self.wizard("dragging",old_button_mode)
-                elif wiz.__class__ != 'pymol.wizard.dragging.Dragging':
+                elif not isinstance(wiz, pymol.wizard.dragging.Dragging):
                     _self.wizard("dragging",old_button_mode)
                 else:
                     wiz.recount()


### PR DESCRIPTION
Two changes included here for Python 3 compatibility:
  * String comparisons with `__class__` are the wrong way to look at types in Python 3, `isinstance` is better
  * `cmp` no longer exists in Python 3 and for sorting, comparison functions such as `__gt__` and `__eq__` must be given instead
