### PR TITLE
Export maps with cmd.dump

### DIFF
--- a/layer2/ObjectMap.cpp
+++ b/layer2/ObjectMap.cpp
@@ -5979,20 +5979,19 @@ void ObjectMapDump(ObjectMap* om, const char* fname, int state, int quiet)
   for (int xi = 0; xi < oms->Field->dimensions[0]; xi++) {
     for (int yi = 0; yi < oms->Field->dimensions[1]; yi++) {
       for (int zi = 0; zi < oms->Field->dimensions[2]; zi++) {
-        float x = oms->ExtentMin[0] + xs * xi;
-        float y = oms->ExtentMin[1] + ys * yi;
-        float z = oms->ExtentMin[2] + zs * zi;
-        
-        CField* field = oms->Field->data;
-        
-        switch (field->type) {
+
+        float x = Ffloat4(oms->Field->points, xi, yi, zi, 0);
+        float y = Ffloat4(oms->Field->points, xi, yi, zi, 1);
+        float z = Ffloat4(oms->Field->points, xi, yi, zi, 2);
+
+        switch (oms->Field->data->type) {
           case cFieldFloat: {
-            float value = Ffloat3(field, xi, yi, zi);
+            float value = Ffloat3(oms->Field->data, xi, yi, zi);
             fprintf(file, "%10.4f%10.4f%10.4f%10.4f\n", x, y, z, value);
             break;
           }
           case cFieldInt: {
-            int value = Fint3(field, xi, yi, zi);
+            int value = Fint3(oms->Field->data, xi, yi, zi);
             fprintf(file, "%10.4f%10.4f%10.4f%10d\n", x, y, z, value);
             break;
           }

--- a/layer2/ObjectMap.cpp
+++ b/layer2/ObjectMap.cpp
@@ -3419,7 +3419,7 @@ static int ObjectMapXPLORStrToMap(ObjectMap * I, char *XPLORStr, int state, int 
 
 
 /*========================================================================*/
-  static int ObjectMapFLDStrToMap(ObjectMap * I, char *PHIStr, int bytes, int state,
+static int ObjectMapFLDStrToMap(ObjectMap * I, char *PHIStr, int bytes, int state,
                                 int quiet)
 {
   char *p;
@@ -5982,10 +5982,24 @@ void ObjectMapDump(ObjectMap* om, const char* fname, int state, int quiet)
         float y = oms->ExtentMin[1] + ys * yi;
         float z = oms->ExtentMin[2] + zs * zi;
         
-        float* field = (float*) oms->Field->data->data;
-        float value = value = field[offset];
+        CField* field = oms->Field->data;
         
-        fprintf(file, "%10.4f%10.4f%10.4f%10.4f\n", x, y, z, value);
+        switch (field->type) {
+          case cFieldFloat: {
+            float value = ((float*)field->data)[offset];
+            fprintf(file, "%10.4f%10.4f%10.4f%10.4f\n", x, y, z, value);
+            break;
+          }
+          case cFieldInt: {
+            int value = ((int*)field->data)[offset];
+            fprintf(file, "%10.4f%10.4f%10.4f%10d\n", x, y, z, value);
+            break;
+          }
+          default:
+            ErrMessage(om->G, "ObjectMapDump", "unknown field type");
+        }
+        
+        
         offset += 1;
       }
     }

--- a/layer2/ObjectMap.cpp
+++ b/layer2/ObjectMap.cpp
@@ -44,6 +44,7 @@ Z* -------------------------------------------------------------------
 #include"CGO.h"
 #include"File.h"
 #include"Executive.h"
+#include"Field.h"
 
 #define n_space_group_numbers 231
 static const char * space_group_numbers[] = {
@@ -5986,19 +5987,18 @@ void ObjectMapDump(ObjectMap* om, const char* fname, int state, int quiet)
         
         switch (field->type) {
           case cFieldFloat: {
-            float value = ((float*)field->data)[offset];
+            float value = Ffloat3(field, xi, yi, zi);
             fprintf(file, "%10.4f%10.4f%10.4f%10.4f\n", x, y, z, value);
             break;
           }
           case cFieldInt: {
-            int value = ((int*)field->data)[offset];
+            int value = Fint3(field, xi, yi, zi);
             fprintf(file, "%10.4f%10.4f%10.4f%10d\n", x, y, z, value);
             break;
           }
           default:
             ErrMessage(om->G, "ObjectMapDump", "unknown field type");
         }
-        
         
         offset += 1;
       }

--- a/layer2/ObjectMap.cpp
+++ b/layer2/ObjectMap.cpp
@@ -3419,7 +3419,7 @@ static int ObjectMapXPLORStrToMap(ObjectMap * I, char *XPLORStr, int state, int 
 
 
 /*========================================================================*/
-static int ObjectMapFLDStrToMap(ObjectMap * I, char *PHIStr, int bytes, int state,
+  static int ObjectMapFLDStrToMap(ObjectMap * I, char *PHIStr, int bytes, int state,
                                 int quiet)
 {
   char *p;
@@ -5964,30 +5964,29 @@ void ObjectMapDump(ObjectMap* om, const char* fname, int state, int quiet)
     ErrMessage(om->G, "ObjectMapDump", "can't open file for writing");
   }
   
-  ObjectMapState* oms = om->State + 0;
+  ObjectMapState* oms = &om->State[state];
   
-  int zd = oms->Field->dimensions[2];
-  int yd = oms->Field->dimensions[1];
   int xd = oms->Field->dimensions[0];
+  int yd = oms->Field->dimensions[1];
+  int zd = oms->Field->dimensions[2];
   
-  float zs = (oms->ExtentMax[2] - oms->ExtentMin[2]) / (oms->Field->dimensions[2]);
-  float ys = (oms->ExtentMax[1] - oms->ExtentMin[1]) / (oms->Field->dimensions[1]);
   float xs = (oms->ExtentMax[0] - oms->ExtentMin[0]) / (oms->Field->dimensions[0]);
+  float ys = (oms->ExtentMax[1] - oms->ExtentMin[1]) / (oms->Field->dimensions[1]);
+  float zs = (oms->ExtentMax[2] - oms->ExtentMin[2]) / (oms->Field->dimensions[2]);
   
   int offset = 0;
-  for (int zi = 0; zi < oms->Field->dimensions[2]; zi++) {
+  for (int xi = 0; xi < oms->Field->dimensions[0]; xi++) {
     for (int yi = 0; yi < oms->Field->dimensions[1]; yi++) {
-      for (int xi = 0; xi < oms->Field->dimensions[0]; xi++) {
-        
-        float z = oms->ExtentMin[2] + zs * zi;
-        float y = oms->ExtentMin[1] + ys * yi;
+      for (int zi = 0; zi < oms->Field->dimensions[2]; zi++) {
         float x = oms->ExtentMin[0] + xs * xi;
+        float y = oms->ExtentMin[1] + ys * yi;
+        float z = oms->ExtentMin[2] + zs * zi;
         
-        float* data = (float*) oms->Field->data->data;
-        float value = data[offset];
-        offset += 1;
+        float* field = (float*) oms->Field->data->data;
+        float value = value = field[offset];
         
         fprintf(file, "%10.4f%10.4f%10.4f%10.4f\n", x, y, z, value);
+        offset += 1;
       }
     }
   }

--- a/layer2/ObjectMap.h
+++ b/layer2/ObjectMap.h
@@ -157,6 +157,8 @@ int ObjectMapStateGetHistogram(PyMOLGlobals * G, ObjectMapState * ms,
                                int n_points, float limit, float *histogram,
                                float min_arg, float max_arg);
 
+void ObjectMapDump(ObjectMap* I, const char* fname, int state, int quiet);
+
 /*========================================================================*/
 inline
 ObjectMapState * getObjectMapState(PyMOLGlobals * G, ObjectMap * I, int state) {

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -29,6 +29,7 @@
 #include"OOMac.h"
 #include"Executive.h"
 #include"SpecRec.h"
+#include"ObjectMap.h"
 #include"ObjectMesh.h"
 #include"ObjectDist.h"
 #include"ObjectSurface.h"
@@ -14653,9 +14654,8 @@ void ExecutiveDump(PyMOLGlobals * G, const char *fname, const char *obj, int sta
 {
   SpecRec *rec = NULL;
   CExecutive *I = G->Executive;
-
+  
   SceneUpdate(G, false);
-
   while(ListIterate(I->Spec, rec, next)) {
     if(rec->type == cExecObject) {
       if(strcmp(rec->obj->Name, obj) == 0)
@@ -14667,6 +14667,8 @@ void ExecutiveDump(PyMOLGlobals * G, const char *fname, const char *obj, int sta
       ObjectMeshDump((ObjectMesh *) rec->obj, fname, state, quiet);
     } else if(rec->obj->type == cObjectSurface) {
       ObjectSurfaceDump((ObjectSurface *) rec->obj, fname, state, quiet);
+    } else if (rec->obj->type == cObjectMap) {
+      ObjectMapDump((ObjectMap *) rec->obj, fname, state, quiet);
     } else {
       ErrMessage(G, __func__, "Invalid object type for this operation.");
     }

--- a/modules/pymol/experimenting.py
+++ b/modules/pymol/experimenting.py
@@ -138,8 +138,8 @@ DESCRIPTION
 DESCRIPTION
 
     The dump command writes the geometry of an isosurface, isomesh,
-    or isodot object to a simple text file. Each line contains one
-    vertex.
+    isodot, or map object to a simple text file. Each line contains one
+    vertex in case of representations, or one grid point in case of a map.
 
     For surface objects, XYZ coordinates and the normal are exported.
     Three lines make one triangle (like GL_TRIANGLES).
@@ -148,7 +148,10 @@ DESCRIPTION
     The vertices form line strips (like GL_LINE_STRIP), a blank
     line starts a new strip.
 
-    For dot objects, XYZ coordinates are exported. 
+    For dot objects, XYZ coordinates are exported.
+
+    For map objects, XYZ coordinates and the value at the point are
+    exported. This forms a grid map.
 
 USAGE
 
@@ -162,6 +165,8 @@ ARGUMENTS
 EXAMPLE
 
     fetch 1ubq, mymap, type=2fofc, async=0
+
+    dump gridmap.txt, mymap
 
     isosurface mysurface, mymap
     dump surfacegeometry.txt, mysurface


### PR DESCRIPTION
Hi,

Currently I'm `cmd.dump`ing isodots level by level until have a filled volume. But with these changes I can get the original grid map which is better.

Unfortunately I was confused about the ttt matrix and don't know how to transform coordinates.

For clearance floats with sizeof 2 was ignored and I have no way to test data grids, only float.
