### PR TITLE
Include <cstddef> in ov_types.h.

### DIFF
--- a/layer0/os_predef.h
+++ b/layer0/os_predef.h
@@ -82,11 +82,7 @@ Z* -------------------------------------------------------------------
 
 /* END PROPRIETARY CODE SEGMENT */
 
-#ifdef __linux__
-#include <malloc.h>
-#else
 #include <stddef.h>
-#endif
 
 #if defined(_MSC_VER)
 // conversion from '...' to '...', possible loss of data

--- a/ov/src/ov_port.h
+++ b/ov/src/ov_port.h
@@ -11,12 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-
-#ifdef __linux__
-#include <malloc.h>
-#else
 #include <stddef.h>
-#endif
 
 #include "ov_defines.h"
 #include "ov_status.h"

--- a/ov/src/ov_types.h
+++ b/ov/src/ov_types.h
@@ -11,6 +11,8 @@
 #ifndef _H_ov_types
 #define _H_ov_types
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
On musl libc, ptrdiff_t, the type used in this header's typedefs, isn't
pulled in by any other include, so it is necessary to include <cstddef>
directly.