### PR TITLE
Fixing SYBYL atom types for Sulphoxide sulphur (S.o) and Sulphone sulphur (S.o2)

### DIFF
--- a/layer2/Mol2Typing.cpp
+++ b/layer2/Mol2Typing.cpp
@@ -163,8 +163,8 @@ const char * getMOL2Type(ObjectMolecule * obj, int atm) {
 
     case cAN_S:
       switch (sulfurCountOxygenNeighbors(obj, atm)) {
-        case 1: return "S.O";
-        case 2: return "S.O2";
+        case 1: return "S.o";
+        case 2: return "S.o2";
       }
       switch (ai->geom) {
         case cAtomInfoPlanar:       return "S.2";


### PR DESCRIPTION
The SYBYL atom typing for Sulphoxide sulphur (S.o) and Sulphone sulphur (S.o2) doesn't match the SYBYL nomenclature (https://www.sdsc.edu/CCMS/Packages/cambridge/pluto/atom_types.html)