### PR TITLE
Fix guide selector bug

### DIFF
--- a/layer3/Selector.cpp
+++ b/layer3/Selector.cpp
@@ -7602,7 +7602,7 @@ static int SelectorSelect0(PyMOLGlobals * G, EvalElem * passed_base)
   case SELE_GIDz:
     for(a = cNDummyAtoms; a < I->Table.size(); a++)
       base[0].sele[a] =
-        I->Obj[I->Table[a].model]->AtomInfo[I->Table[a].atom].flags & cAtomFlag_guide;
+        bool(I->Obj[I->Table[a].model]->AtomInfo[I->Table[a].atom].flags & cAtomFlag_guide);
     break;
 
   case SELE_PREz:


### PR DESCRIPTION
The underlying issue could be the negative value of `base[0].sele[a]` or the signed/unsigned mismatch of `base[0].sele[a]` and `AtomInfoType.flags` (less likely, but I don't know...).

Casting to a `bool` fixes this particular issue.

Closes https://github.com/schrodinger/pymol-open-source/issues/198