### PR TITLE
Add `fetch_path` to `is_session_blacklisted`

### DIFF
--- a/layer1/Setting.cpp
+++ b/layer1/Setting.cpp
@@ -639,6 +639,7 @@ static bool is_session_blacklisted(int index) {
   case cSetting_cylinder_shader_ff_workaround:
   case cSetting_defer_updates:
   case cSetting_fast_idle:
+  case cSetting_fetch_path:
   case cSetting_internal_feedback:
   case cSetting_internal_gui:
   case cSetting_internal_prompt:


### PR DESCRIPTION
The `fetch_path` setting is usually not meaningful across different computers. Opening a session file which has `fetch_path` set to a location which doesn't exist on the current computer will make the `fetch` command fail to save files.