### PR TITLE
More consistent cmd.load_model discrete behavior

### DIFF
--- a/layer2/ObjectMolecule.cpp
+++ b/layer2/ObjectMolecule.cpp
@@ -7209,8 +7209,8 @@ ObjectMolecule *ObjectMoleculeLoadChemPyModel(PyMOLGlobals * G,
       std::swap(atInfo, I->AtomInfo);
       isNew = true;
     } else {
-      if (discrete)
-	ObjectMoleculeSetDiscrete(G, I, true);
+      if (discrete > -1)
+        ObjectMoleculeSetDiscrete(G, I, discrete);
     }
 
     if(isNew) {

--- a/layer3/ExecutivePython.cpp
+++ b/layer3/ExecutivePython.cpp
@@ -28,8 +28,6 @@ pymol::Result<> ExecutiveLoadObject(PyMOLGlobals* G,
       if (origObj->type != cObjectMolecule) {
         ExecutiveDelete(G, valid_name);
         origObj = NULL;
-      } else {
-        discrete = 1;
       }
     }
     PBlock(G); /*PBlockAndUnlockAPI(); */


### PR DESCRIPTION
- Allow `discrete=0` for multi-state objects
- Keep existing discrete flag with `discrete=-1`

Fixes https://github.com/schrodinger/pymol-open-source/issues/212