### PR TITLE
Fix fallback MMTF loader

### DIFF
--- a/layer1/P.cpp
+++ b/layer1/P.cpp
@@ -1987,6 +1987,7 @@ void PInit(PyMOLGlobals * G, int global_instance)
   // fallback MMTF support
   PyRun_SimpleString(
       "import pymol.importing;"
+      "pymol.importing.loadable.mmtf = None;"
       "pymol.importing.loadfunctions.setdefault('mmtf',"
       "pymol.importing.load_mmtf)");
 #endif

--- a/modules/chempy/mmtf/__init__.py
+++ b/modules/chempy/mmtf/__init__.py
@@ -2,17 +2,7 @@
 Experimental MMTF (Macromolecular Transmission Format) support
 '''
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-try:
-    from itertools import izip
-    as_str = str
-except ImportError:
-    # python3
-    izip = zip
-    as_str = lambda s: s if isinstance(s, str) else s.decode()
+as_str = lambda s: s if isinstance(s, str) else s.decode("utf-8")
 
 #####################################################################
 
@@ -90,22 +80,22 @@ def _to_chempy(data, use_auth=True):
                     islice(group_iter, n_groups):
 
                 group = groupList[groupType]
-                resn = as_str(group[b'groupName'])
+                resn = as_str(group['groupName'])
 
-                group_bond_iter = izip(
-                        group[b'bondAtomList'][0::2],
-                        group[b'bondAtomList'][1::2],
-                        group[b'bondOrderList'],
+                group_bond_iter = zip(
+                        group['bondAtomList'][0::2],
+                        group['bondAtomList'][1::2],
+                        group['bondOrderList'],
                         )
 
                 offset = len(model.atom)
                 for (i1, i2, order) in group_bond_iter:
                     add_bond(i1, i2, order, offset)
 
-                group_atom_iter = izip(
-                        group[b'atomNameList'],
-                        group[b'elementList'],
-                        group[b'formalChargeList'],
+                group_atom_iter = zip(
+                        group['atomNameList'],
+                        group['elementList'],
+                        group['formalChargeList'],
                         )
 
                 for (name, elem, formal_charge) in group_atom_iter:

--- a/modules/chempy/mmtf/io.py
+++ b/modules/chempy/mmtf/io.py
@@ -21,7 +21,7 @@ if True:
     from urllib.request import urlopen
     izip = zip
     izip_longest = itertools.zip_longest
-    as_msgpack_key = lambda k: k if isinstance(k, bytes) else k.encode()
+    as_msgpack_key = lambda k: k if isinstance(k, str) else k.decode("utf-8")
     buffer = lambda s, i=0: memoryview(s)[i:]
 
 # should be replaced with a more efficient numpy-array aware iterator
@@ -218,13 +218,13 @@ class MmtfReader:
     def __init__(self, data):
         if isinstance(data, bytes):
             if data[:2] != b'\x1f\x8b': # gzip magic number
-                self._data = msgpack.unpackb(data)
+                self._data = msgpack.unpackb(data, raw=False)
                 return
 
             import io, gzip
             data = gzip.GzipFile(fileobj=io.BytesIO(data))
 
-        self._data = msgpack.unpack(data)
+        self._data = msgpack.unpack(data, raw=False)
 
     @classmethod
     def from_url(cls, url):
@@ -238,7 +238,7 @@ class MmtfReader:
         except KeyError:
             return default
 
-        if not (key.endswith(b'List') and isinstance(value, bytes)):
+        if not (key.endswith('List') and isinstance(value, bytes)):
             return value
 
         return decode(value)

--- a/modules/pymol/importing.py
+++ b/modules/pymol/importing.py
@@ -907,7 +907,8 @@ EXAMPLE
             multiplex=-2
         ftype = getattr(loadable, format, None)
         if ftype is None:
-            assert format not in ('cif', 'mmtf', 'pdb', 'dx')
+            assert format not in ('cif', 'pdb', 'dx')
+            assert format not in ('mmtf', ) or format in loadfunctions
 
             if not isinstance(content, bytes):
                 content = content.encode("utf-8")


### PR DESCRIPTION
Fixes `chempy.mmtf` with `msgpack-python` 1.0.

Also makes it work with `cmd.load_raw` and pass the corresponding tests.

Fixes https://github.com/schrodinger/pymol-open-source/issues/225