### PR TITLE
iterate: Add explicit_valence and explicit_degree

### DIFF
--- a/layer1/P.h
+++ b/layer1/P.h
@@ -50,7 +50,7 @@ Z* -------------------------------------------------------------------
 #define cPType_schar          14
 #define cPType_uint32         15
 
-#define NUM_ATOM_PROPERTIES    41
+#define NUM_ATOM_PROPERTIES    43
 
 #define cPRunType_alter          1
 #define cPRunType_alter_state    2

--- a/layer2/AtomInfo.h
+++ b/layer2/AtomInfo.h
@@ -207,6 +207,8 @@ typedef char ElemName[cElemNameLen + 1];
 // for customType (not geom)
 #define cAtomInfoNoType -9999
 
+#define cBondOrderDeloc 4
+
 inline char makeInscode(char c) {
   return (c <= ' ') ? '\0' : c;
 }
@@ -283,6 +285,11 @@ typedef struct AtomInfoType {
   signed char formalCharge;     // values typically in range -2..+2
   signed char cartoon;          /* 0 = default which is auto (use ssType) */
   signed char geom;             // cAtomInfo*
+
+  // "valence" should be renamed to "degree" (or "total_degree"). It's the
+  // number of explicit and implicit neighbors, independent of bond order.
+  // Should be equivalent to RDKit::Atom::getTotalDegree() and
+  // OBAtom::GetTotalDegree().
   signed char valence;          // 0-4
   signed char protons;          /* atomic number */
 

--- a/layer5/PyMOL.cpp
+++ b/layer5/PyMOL.cpp
@@ -197,6 +197,8 @@ typedef struct _CPyMOL {
     lex_atom_prop_stereo, lex_atom_prop_cartoon, lex_atom_prop_color,
     lex_atom_prop_ID, lex_atom_prop_rank, lex_atom_prop_flags,
     lex_atom_prop_geom, lex_atom_prop_valence,
+    lex_atom_prop_explicit_degree,
+    lex_atom_prop_explicit_valence,
     lex_atom_prop_x, lex_atom_prop_y, lex_atom_prop_z,
     lex_atom_prop_settings, lex_atom_prop_properties,
     lex_atom_prop_reps,
@@ -613,6 +615,8 @@ static OVstatus PyMOL_InitAPI(CPyMOL * I)
   LEX_ATOM_PROP(reps, 38, cPType_int, offsetof(AtomInfoType, visRep));
   LEX_ATOM_PROP(protons, 39, cPType_schar, offsetof(AtomInfoType, protons));
   LEX_ATOM_PROP(oneletter, 40, 0, 0);
+  LEX_ATOM_PROP(explicit_degree, ATOM_PROP_EXPLICIT_DEGREE, 0, 0);
+  LEX_ATOM_PROP(explicit_valence, ATOM_PROP_EXPLICIT_VALENCE, 0, 0);
   //  LEX_ATOM_PROP(, );
 
   return_OVstatus_SUCCESS;

--- a/layer5/PyMOL.h
+++ b/layer5/PyMOL.h
@@ -154,6 +154,8 @@ typedef struct _CPyMOL CPyMOL;
 #define ATOM_PROP_SETTINGS 33
 #define ATOM_PROP_PROPERTIES 34
 #define ATOM_PROP_ONELETTER 40
+#define ATOM_PROP_EXPLICIT_DEGREE 41
+#define ATOM_PROP_EXPLICIT_VALENCE 42
 
 /* return status values */
 

--- a/modules/pymol/completing.py
+++ b/modules/pymol/completing.py
@@ -24,6 +24,8 @@ expr_sc = ExprShortcut([
     'oneletter',
     'model', 'resv', 'type', 'stereo', 'rank', 'index', 'ss', 'color', 'reps',
     'protons', 'label', 'geom', 'valence', 'flags', 'cartoon',
+    'explicit_degree',
+    'explicit_valence',
 ])
 
 


### PR DESCRIPTION
Add `explicit_valence` (sum of bond orders) and `explicit_degree` (number of directly-bonded neighbors) to `cmd.iterate`. These properties should be equivalent to [OBAtom::GetExplicitValence()](https://openbabel.github.io/api/3.0/classOpenBabel_1_1OBAtom.shtml#a3037ede30cf1ba5fe88d85f0e215e53a), [OBAtom::GetExplicitDegree()](https://openbabel.github.io/api/3.0/classOpenBabel_1_1OBAtom.shtml#ad5700b224315119362b624867f0e9aa4) and [RDKit::Atom::getDegree()](https://www.rdkit.org/docs/source/rdkit.Chem.rdchem.html#rdkit.Chem.rdchem.Atom.GetDegree).

Example:
```python
from pymol import cmd

def test_explicit_degree():
    cmd.reinitialize()
    cmd.fragment("ala")
    result = []
    cmd.iterate("all", "result.append(explicit_degree)", space=locals())
    assert result == [2, 4, 2, 1, 4, 1, 1, 1, 1, 1]

def test_explicit_valence():
    cmd.reinitialize()
    cmd.fragment("ala")
    result = []
    cmd.iterate("all", "result.append(explicit_valence)", space=locals())
    assert result == [2, 4, 3, 2, 4, 1, 1, 1, 1, 1]

def test_explicit_valence__aromatic():
    cmd.reinitialize()
    cmd.fragment("benzene")
    cmd.valence("aromatic", "elem C", "elem C")
    result = []
    cmd.iterate("all", "result.append(explicit_valence)", space=locals())
    assert result == [4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1]

test_explicit_degree()
test_explicit_valence()
test_explicit_valence__aromatic()
```