### PR TITLE
Fix for missing scene panel dialog in Tk GUI

### DIFF
--- a/modules/pmg_tk/skins/normal/__init__.py
+++ b/modules/pmg_tk/skins/normal/__init__.py
@@ -99,6 +99,9 @@ class Normal(PMGSkin, pymol._gui.PyMOLDesktopGUI):
     contactweb     = 'http://www.pymol.org'
     contactemail   = 'sales@schrodinger.com'
     
+    def scene_panel_menu_dialog(self):
+        print("scene_panel_menu_dialog not available in pmg_tk.")
+
     # responsible for setup and takedown of the normal skin
 
     def _inc_fontsize(self, delta, font):


### PR DESCRIPTION
This is a PR for Issue #189. The original issue report mentions this workaround but a PR was never created. Absence of this workaround makes Tk PyMol unusable.