### PR TITLE
Fix crash in find_molfile_plugin

### DIFF
--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -735,9 +735,8 @@ static PyObject * CmdFindMolfilePlugin(PyObject * self, PyObject * args)
     if (G) {
       APIEnter(G);
       const char * plugin = PlugIOManagerFindPluginByExt(G, ext, mask);
-      PyObject * result = PyString_FromString(plugin ? plugin : "");
       APIExit(G);
-      return APIAutoNone(result);
+      return PyUnicode_FromString(plugin ? plugin : "");
     }
   }
   return APIAutoNone(NULL);


### PR DESCRIPTION
Was calling Python function with unblocked interpreter (before `APIExit(G)`).

Caused a crash for on Linux with self-compiled PyMOL and trying to load an unsupported file format.