### PR TITLE
New setting: cell_centered

### DIFF
--- a/layer0/Crystal.cpp
+++ b/layer0/Crystal.cpp
@@ -97,6 +97,17 @@ void CrystalDump(const CCrystal * I)
 
 static float unitCellVertices[][3] = { {0,0,0}, {1,0,0}, {1,1,0}, {0,1,0}, // bottom 4 vertices
 				       {0,0,1}, {1,0,1}, {1,1,1}, {0,1,1} }; // top 4 vertices
+static float const unitCellVerticesCentered[][3] = {
+    {-0.5, -0.5, -0.5},
+    {0.5, -0.5, -0.5},
+    {0.5, 0.5, -0.5},
+    {-0.5, 0.5, -0.5},
+    {-0.5, -0.5, 0.5},
+    {0.5, -0.5, 0.5},
+    {0.5, 0.5, 0.5},
+    {-0.5, 0.5, 0.5},
+};
+
 static int unitCellLineIndices[] = { 0, 1, 1, 2, 2, 3, 3, 0,   // bottom 4 lines
 				     4, 5, 5, 6, 6, 7, 7, 4,   // top 4 lines
 				     0, 4, 1, 5, 2, 6, 3, 7 }; // 4 connector lines
@@ -106,13 +117,18 @@ CGO *CrystalGetUnitCellCGO(const CCrystal * I)
   PyMOLGlobals *G = I->G;
   float v[3];
   CGO *cgo = NULL;
+
+  auto const ucv = SettingGet<bool>(G, cSetting_cell_centered)
+                       ? unitCellVerticesCentered
+                       : unitCellVertices;
+
   if(I) {
     cgo = CGONew(G);
     CGODisable(cgo, GL_LIGHTING);
 
     float *vertexVals = CGODrawArrays(cgo, GL_LINES, CGO_VERTEX_ARRAY, 24);
     for (int pl = 0; pl < 24 ; pl++){
-      transform33f3f(I->fracToReal(), unitCellVertices[unitCellLineIndices[pl]], v);
+      transform33f3f(I->fracToReal(), ucv[unitCellLineIndices[pl]], v);
       copy3f(v, &vertexVals[pl*3]);
     }
 

--- a/layer1/Setting.cpp
+++ b/layer1/Setting.cpp
@@ -2738,6 +2738,10 @@ void SettingGenerateSideEffects(PyMOLGlobals * G, int index, const char *sele, i
      ExecutiveInvalidateRep(G, inv_sele, cRepNonbonded, cRepInvRep);
      SceneChanged(G);
      break;
+  case cSetting_cell_centered:
+     ExecutiveInvalidateRep(G, inv_sele, cRepCell, cRepInvRep);
+     SceneChanged(G);
+     break;
   case cSetting_dot_width:
   case cSetting_dot_radius:
   case cSetting_dot_density:

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -895,6 +895,7 @@ enum {
   REC_i( 785, cartoon_smooth_cylinder_cycles          , global    , 3 ),
   REC_i( 786, cartoon_smooth_cylinder_window          , global    , 2 ),
   REC_i( 787, isosurface_algorithm                    , global    , 0, 0, 2 ),
+  REC_b( 788, cell_centered                           , global    , false ),
 
 
 #ifdef SETTINGINFO_IMPLEMENTATION

--- a/layer2/CoordSet.cpp
+++ b/layer2/CoordSet.cpp
@@ -1180,6 +1180,11 @@ void CoordSet::invalidateRep(cRep_t type, cRepInv_t level)
     }
   }
 
+  // cell
+  if (type == cRepCell) {
+    UnitCellCGO.reset();
+  }
+
   /* invalidate basd on one representation, 'type' */
   for (RepIterator iter(G, type); iter.next(); ){
     auto eff_level = level;

--- a/layer2/ObjectMolecule.cpp
+++ b/layer2/ObjectMolecule.cpp
@@ -2655,7 +2655,6 @@ bool ObjectMolecule::setSymmetry(CSymmetry const& symmetry, int state)
     auto cs = CSet[iter.state];
     if (cs) {
       cs->Symmetry.reset(all_states ? nullptr : new CSymmetry(symmetry));
-      cs->UnitCellCGO.reset();
       cs->invalidateRep(cRepCell, cRepInvRep);
       success = true;
     }


### PR DESCRIPTION
Add a new setting to render the `cell` representation centered.
```
fragment trp
set_symmetry trp, 8, 8, 8, 90, 90, 90, P1
show cell
```
![cell_centered-0](https://user-images.githubusercontent.com/1239490/194014025-6eef8188-189b-4de0-b9a5-78a9f845b776.png)

```
set cell_centered
```
![cell_centered-1](https://user-images.githubusercontent.com/1239490/194014046-cf80f57a-ce62-4313-bbe0-ed6d79fb5495.png)

Closes https://github.com/schrodinger/pymol-open-source/issues/258