### PR TITLE
Fix crash when loading discrete object

### DIFF
--- a/layer2/RepCartoon.cpp
+++ b/layer2/RepCartoon.cpp
@@ -3721,7 +3721,7 @@ Rep *RepCartoonNew(CoordSet * cs, int state)
 
   /* find all of the CA points */
 
-  auto const nAtIndex = cs->AtmToIdx.size(); // was NAtIndex
+  auto const nAtIndex = obj->NAtom; // was NAtIndex
   at = pymol::malloc<int>(nAtIndex);        /* cs index pointers */
   pv = pymol::malloc<float>(nAtIndex * 3);
   tmp = pymol::malloc<float>(nAtIndex * 3);


### PR DESCRIPTION
Fixes crash for
```
fetch 2xwu, type=cif, discrete=1
```
Follow-up on "PYMOL-3840 Fix cartoon rep memory init" 682572b9789cca856ea2be37bf707acdfb3e3bbb