### PR TITLE
grid mode background color per grid cell

### DIFF
--- a/layer0/PyMOLEnums.h
+++ b/layer0/PyMOLEnums.h
@@ -60,3 +60,10 @@ enum class GridMode
   ByObjectByState = 3, // One slot per state per object
   ByCamera = 4, // One slot per camera
 };
+
+enum class BgGradient
+{
+  None = 0,
+  Vertical = 1,
+  Grid = 2,
+};

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -189,6 +189,8 @@ void SceneRender(PyMOLGlobals* G, const SceneRenderInfo& renderInfo)
 
   G->ShaderMgr->Check_Reload();
 
+  auto const last_grid_shape = std::array<int, 2>{I->grid.n_col, I->grid.n_row};
+
   auto grid_mode = SettingGet<GridMode>(G, cSetting_grid_mode);
   int grid_size = 0;
   if (grid_mode != GridMode::NoGrid) {
@@ -199,6 +201,14 @@ void SceneRender(PyMOLGlobals* G, const SceneRenderInfo& renderInfo)
   } else {
     I->grid.active = false;
   }
+
+  auto const grid_shape = std::array<int, 2>{I->grid.n_col, I->grid.n_row};
+
+  if (last_grid_shape != grid_shape &&
+      SettingGet<BgGradient>(G, cSetting_bg_gradient) == BgGradient::Grid) {
+    OrthoBackgroundTextureNeedsUpdate(G);
+  }
+
   if (last_grid_active != I->grid.active || grid_size != I->last_grid_size) {
     G->ShaderMgr->ResetUniformSet();
   }

--- a/layer1/Setting.cpp
+++ b/layer1/Setting.cpp
@@ -2755,6 +2755,7 @@ void SettingGenerateSideEffects(PyMOLGlobals * G, int index, const char *sele, i
   case cSetting_bg_gradient:
       ColorUpdateFrontFromSettings(G);
       ExecutiveInvalidateRep(G, inv_sele, cRepAll, cRepInvColor);
+    OrthoBackgroundTextureNeedsUpdate(G);
     G->ShaderMgr->Set_Reload_Bits(RELOAD_VARIABLES);
     SceneChanged(G);
     break;

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -759,7 +759,7 @@ enum {
   REC_s( 659, default_2fofc_map_rep                   , global    , "volume" ),
   REC_s( 660, atom_type_format                        , global    , "mol2" ),
   REC_b( 661, autoclose_dialogs                       , global    , 1 ),
-  REC_b( 662, bg_gradient                             , global    , 0 ),
+  REC_i( 662, bg_gradient                             , global    , 0 ),
   REC_c( 663, bg_rgb_top                              , global    , "0x00004D" ),
   REC_c( 664, bg_rgb_bottom                           , global    , "0x333380" ),
   REC_b( 665, ray_volume                              , global    , 0 ),


### PR DESCRIPTION
This patch is a possible solution for https://github.com/schrodinger/pymol-open-source/issues/267, implemented as a background texture. It adds a new `bg_gradient` mode.

Example:
```
fragment ala
fragment cys
fragment gly

set grid_mode
set bg_gradient, 2
set bg_image_linear, 0
```

To facilitate a nice implementation, I first refactored the `bg_grad` function in a separate commit.