### PR TITLE
Avoid 3x2 grid for size=4

### DIFF
--- a/layer1/Scene.cpp
+++ b/layer1/Scene.cpp
@@ -194,6 +194,16 @@ void GridUpdate(GridInfo * I, float asp_ratio, GridMode mode, int size)
         else
           n_row++;
       }
+
+      // the above algorithm can generate a 3x2 grid for size=4, but we want a
+      // 2x2 in that case.
+      while ((n_col - 1) * n_row >= size) {
+        n_col -= 1;
+      }
+      while ((n_row - 1) * n_col >= size) {
+        n_row -= 1;
+      }
+
       I->n_row = n_row;
       I->n_col = n_col;
     }


### PR DESCRIPTION
This pull request optimizes the number of columns and rows in grid mode. Previously, you could easily end up with a 3x2 instead of 2x2 grid with 4 elements, or a 4x2 instead of 3x2 grid for 5 elements.

Example:
```
set grid_mode
viewport 800, 400
fragment gly, m1
fragment gly, m2
fragment gly, m3
fragment gly, m4
```
| Current master        | This Pull Request  |
| ------------- |-----|
| ![grid-old](https://user-images.githubusercontent.com/1239490/216675906-1a0039f5-b48c-46b5-bd71-f8dde8984ba4.png) | ![grid-new](https://user-images.githubusercontent.com/1239490/216675382-3be2cdce-758e-4eb7-aaae-6d107350b033.png) |
