### PR TITLE
Fix infinite loop with grid_mode and no objects

### DIFF
--- a/layer1/Scene.cpp
+++ b/layer1/Scene.cpp
@@ -197,10 +197,10 @@ void GridUpdate(GridInfo * I, float asp_ratio, GridMode mode, int size)
 
       // the above algorithm can generate a 3x2 grid for size=4, but we want a
       // 2x2 in that case.
-      while ((n_col - 1) * n_row >= size) {
+      while ((n_col - 1) * n_row >= size && size) {
         n_col -= 1;
       }
-      while ((n_row - 1) * n_col >= size) {
+      while ((n_row - 1) * n_col >= size && size) {
         n_row -= 1;
       }
 


### PR DESCRIPTION
Regression of d0a3380636e3d4079a0320b372a330dcf797d660

This causes an infinite loop:
```
set grid_mode
delete *
```