### PR TITLE
Refactoring: enum cAtomProtected_*

### DIFF
--- a/layer1/SceneMouse.cpp
+++ b/layer1/SceneMouse.cpp
@@ -538,7 +538,7 @@ void SceneClickPickBond(PyMOLGlobals* G, int x, int y, int mode, const NamedPick
       I->SculptingFlag = 1;
       I->SculptingSave =
           obj->AtomInfo[LastPicked.src.index].protekted;
-      obj->AtomInfo[LastPicked.src.index].protekted = 2;
+      obj->AtomInfo[LastPicked.src.index].protekted = cAtomProtected_drag;
     }
     WizardDoPick(G, 1, LastPicked.context.state);
   } else {
@@ -713,7 +713,7 @@ static int SceneClick(
         G, button, mod); /* trying to work around something... */
 
     I->Button = button;
-    I->SculptingSave = 0;
+    I->SculptingSave = cAtomProtected_off;
     switch (mode) {
     case cButModeScaleSlabExpand:
       SceneNoteMouseInteraction(G);
@@ -995,7 +995,7 @@ static int SceneClick(
               I->SculptingFlag = 1;
               I->SculptingSave =
                   objMol->AtomInfo[I->LastPicked.src.index].protekted;
-              objMol->AtomInfo[I->LastPicked.src.index].protekted = 2;
+              objMol->AtomInfo[I->LastPicked.src.index].protekted = cAtomProtected_drag;
             }
           }
           break;

--- a/layer2/AtomInfo.h
+++ b/layer2/AtomInfo.h
@@ -35,6 +35,12 @@ Z* -------------------------------------------------------------------
 #define BondInfoVERSION  181
 #endif
 
+enum {
+  cAtomProtected_off = 0,
+  cAtomProtected_explicit = 1,
+  cAtomProtected_drag = 2,
+};
+
 /* FLAGS 0-3 have the following conventional usage for molecular modeling */
 
 

--- a/layer2/ObjectMolecule.cpp
+++ b/layer2/ObjectMolecule.cpp
@@ -6291,7 +6291,7 @@ int ObjectMoleculeTransformSelection(ObjectMolecule * I, int state,
           ai = I->AtomInfo;
           for(a = 0; a < I->NAtom; a++) {
             s = ai->selEntry;
-            if(!(ai->protekted == 1))
+            if(!(ai->protekted == cAtomProtected_explicit))
               if(SelectorIsMember(G, s, sele)) {
                 if(homogenous)
                   CoordSetTransformAtomR44f(cs, a, matrix);
@@ -6305,7 +6305,7 @@ int ObjectMoleculeTransformSelection(ObjectMolecule * I, int state,
           if(!use_matrices) {
             ai = I->AtomInfo;
             for(a = 0; a < I->NAtom; a++) {
-              if(!(ai->protekted == 1)) {
+              if(!(ai->protekted == cAtomProtected_explicit)) {
                 if(homogenous)
                   CoordSetTransformAtomR44f(cs, a, matrix);
                 else
@@ -10708,7 +10708,7 @@ int ObjectMoleculeMoveAtom(ObjectMolecule * I, int state, int index, const float
   int result = 0;
   PyMOLGlobals *G = I->G;
   CoordSet *cs;
-  if(!(I->AtomInfo[index].protekted == 1)) {
+  if(!(I->AtomInfo[index].protekted == cAtomProtected_explicit)) {
     if(state < 0)
       state = 0;
     if(I->NCSet == 1)
@@ -10741,7 +10741,7 @@ int ObjectMoleculeMoveAtomLabel(ObjectMolecule * I, int state, int index, float 
 {
   int result = 0;
   CoordSet *cs;
-  if(!(I->AtomInfo[index].protekted == 1)) {
+  if(!(I->AtomInfo[index].protekted == cAtomProtected_explicit)) {
     if(state < 0)
       state = 0;
     if(I->NCSet == 1)

--- a/layer2/Sculpt.cpp
+++ b/layer2/Sculpt.cpp
@@ -1785,7 +1785,7 @@ float SculptIterateObject(CSculpt * I, ObjectMolecule * obj,
           a = *(a_ptr++);
           {
             AtomInfoType *ai = obj->AtomInfo + a;
-            if((ai->protekted != 1) && !(ai->flags & cAtomFlag_fix)) {
+            if((ai->protekted != cAtomProtected_explicit) && !(ai->flags & cAtomFlag_fix)) {
               v2 = cs_coord + 3 * atm2idx[a];
               center[4] += *(v2);
               center[5] += *(v2 + 1);
@@ -2157,7 +2157,8 @@ float SculptIterateObject(CSculpt * I, ObjectMolecule * obj,
                                 a1 = atm2idx[b1];
                                 v1 = cs_coord + 3 * a1;
                                 if(vdw_vis_mode && cgo && (n_cycle < 1)
-                                   && ((!((ai0->protekted && ai1->protekted)
+                                   && ((!((ai0->protekted != cAtomProtected_off &&
+                                           ai1->protekted != cAtomProtected_off)
                                           || (ai0->flags & ai1->flags & cAtomFlag_fix))
                                        ) || (ai0->flags & cAtomFlag_study)
                                        || (ai1->flags & cAtomFlag_study))) {
@@ -2299,7 +2300,7 @@ float SculptIterateObject(CSculpt * I, ObjectMolecule * obj,
               AtomInfoType *ai = obj->AtomInfo + a;
               const RefPosType *cs_refpos = cs->RefPos.data();
               int flags;
-              if(!(ai->protekted || ((flags = ai->flags) & cAtomFlag_fix))) {
+              if(!(ai->protekted != cAtomProtected_off || ((flags = ai->flags) & cAtomFlag_fix))) {
                 v1 = disp + 3 * a;
                 v2 = cs_coord + 3 * atm2idx[a];
 
@@ -2336,7 +2337,7 @@ float SculptIterateObject(CSculpt * I, ObjectMolecule * obj,
               int a = *(a_ptr++);
               {
                 AtomInfoType *ai = obj->AtomInfo + a;
-                if((ai->protekted != 1) && !(ai->flags & cAtomFlag_fix)) {
+                if((ai->protekted != cAtomProtected_explicit) && !(ai->flags & cAtomFlag_fix)) {
                   v2 = cs_coord + 3 * atm2idx[a];
                   center[0] += *(v2);
                   center[1] += *(v2 + 1);

--- a/layer3/Selector.cpp
+++ b/layer3/Selector.cpp
@@ -4013,7 +4013,7 @@ int SelectorWalkTree(PyMOLGlobals * G, int *atom, int *comp, int *toDo, int **st
         SelectorIsMember(G, s, sele1) || SelectorIsMember(G, s, sele2) ||
         SelectorIsMember(G, s, sele3) || SelectorIsMember(G, s, sele4);
     if(!seleFlag) {
-      if(!(ai->protekted == 1)) {       /* if not explicitly protected... */
+      if(!(ai->protekted == cAtomProtected_explicit)) {       /* if not explicitly protected... */
         atom[a] = 1;            /* mark this atom into the selection */
         comp[a] = 1;
       }
@@ -4090,7 +4090,7 @@ static int SelectorWalkTreeDepth(PyMOLGlobals * G, int *atom, int *comp, int *to
 
     if(!seleFlag) {
       toDo[a] = 0;
-      if(!(ai->protekted == 1)) {       /* if not explicitly protected... */
+      if(!(ai->protekted == cAtomProtected_explicit)) {       /* if not explicitly protected... */
         atom[a] = 1;            /* mark this atom into the selection */
         comp[a] = 1;
       }
@@ -7583,7 +7583,7 @@ static int SelectorSelect0(PyMOLGlobals * G, EvalElem * passed_base)
     break;
   case SELE_PTDz:
     for(a = cNDummyAtoms; a < I->Table.size(); a++)
-      base[0].sele[a] = I->Obj[I->Table[a].model]->AtomInfo[I->Table[a].atom].protekted;
+      base[0].sele[a] = I->Obj[I->Table[a].model]->AtomInfo[I->Table[a].atom].protekted != cAtomProtected_off;
     break;
   case SELE_MSKz:
     for(a = cNDummyAtoms; a < I->Table.size(); a++)


### PR DESCRIPTION
Introducing an `enum` for `AtomInfoType::protekted`.

I tried to understand the [protect](https://pymolwiki.org/index.php/Protect) command better and this refactoring helped.