### PR TITLE
Fix SelectorTmp::getAtomCount() w/ selection name

### DIFF
--- a/layer3/Selector.h
+++ b/layer3/Selector.h
@@ -233,7 +233,7 @@ public:
     SelectorFreeTmp(m_G, m_name);
   }
   const char * getName() const { return m_name; }
-  int getAtomCount() { return m_count; }
+  int getAtomCount();
   SelectorID_t getIndex() const {
     return m_name[0] ? SelectorIndexByName(m_G, m_name, false) : cSelectionInvalid;
   }

--- a/layer3/SelectorTmp.cpp
+++ b/layer3/SelectorTmp.cpp
@@ -15,6 +15,15 @@ SelectorTmp::SelectorTmp(SelectorTmp&& other)
   assert(other.m_count == -1);
 }
 
+int SelectorTmp::getAtomCount()
+{
+  if (m_count != 0) {
+    return m_count;
+  }
+
+  return SelectorCountAtoms(m_G, getIndex(), cSelectorUpdateTableAllStates);
+}
+
 /**
  * Factory which propagates errors.
  * @param sele Selection expression


### PR DESCRIPTION
Fall back to `SelectorCountAtoms()` if `m_count == 0`, which is the case for named selections.

Fixes https://github.com/schrodinger/pymol-open-source/issues/322