### PR TITLE
Fix for broken `png_check_sig` in libpng 1.6.41

### DIFF
--- a/layer0/MyPNG.cpp
+++ b/layer0/MyPNG.cpp
@@ -406,7 +406,7 @@ std::unique_ptr<pymol::Image> MyPNGRead(const char *file_name)
   }
 
   if(ok) {
-    ret = png_check_sig(buf, 8);
+    ret = !png_sig_cmp(buf, 0, 8);
     if(!ret)
       ok = false;
   }


### PR DESCRIPTION
See https://github.com/pnggroup/libpng/issues/534

The bug report says that `png_check_sig` was deprecated many years ago.