### PR TITLE
replace distutils for python 3.12

### DIFF
--- a/create_shadertext.py
+++ b/create_shadertext.py
@@ -7,7 +7,6 @@ import glob
 from collections import defaultdict
 from os.path import dirname
 from subprocess import Popen, PIPE
-from distutils import dir_util
 
 def create_all(generated_dir, pymoldir="."):
     '''
@@ -30,7 +29,7 @@ class openw(object):
             self.out = cStringIO.StringIO()
             self.filename = filename
         else:
-            dir_util.mkpath(os.path.dirname(filename))
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
             self.out = open(filename, "w")
             self.filename = None
     def close(self):

--- a/modules/pymol/plugins/installation.py
+++ b/modules/pymol/plugins/installation.py
@@ -45,8 +45,6 @@ def cmp_version(v1, v2):
     '''
     Compares two version strings. An empty version string is always considered
     smaller than a non-empty version string.
-
-    Uses distutils.version.StrictVersion to evaluate non-empty version strings.
     '''
     if v1 == v2:
         return 0
@@ -55,8 +53,9 @@ def cmp_version(v1, v2):
     if v2 == '':
         return 1
     try:
-        from distutils.version import StrictVersion as Version
-        return cmp(Version(v1), Version(v2))
+        v1_parts = list(map(int, v1.split('.')))
+        v2_parts = list(map(int, v2.split('.')))
+        return (v1_parts > v2_parts) - (v1_parts < v2_parts)
     except:
         print(' Warning: Version parsing failed for', v1, 'and/or', v2)
         return 0

--- a/testing/tests/system/pymolwin.py
+++ b/testing/tests/system/pymolwin.py
@@ -7,7 +7,6 @@ import time
 import subprocess
 import sys
 import unittest
-from distutils.spawn import find_executable
 from pymol import cmd, CmdException, testing, stored
 
 @unittest.skipIf(not sys.platform.startswith('win'), 'windows only')


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed
