### PR TITLE
Include cstdint header for CifFile module

### DIFF
--- a/layer2/CifFile.h
+++ b/layer2/CifFile.h
@@ -8,6 +8,7 @@
 #define _H_CIFFILE
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <memory>


### PR DESCRIPTION
I need `<cstdint>` on Arch Linux with gcc, otherwise `std::int8_t` is not defined.