### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/create_shadertext.py
+++ b/create_shadertext.py
@@ -127,7 +127,7 @@ def create_buildinfo(outputdir, pymoldir='.'):
         print('''
 #define _PyMOL_BUILD_DATE %d
 #define _PYMOL_BUILD_GIT_SHA "%s"
-        ''' % (time.time(), sha), file=out)
+        ''' % (int(os.environ.get('SOURCE_DATE_EPOCH', time.time())), sha), file=out)
 
 if __name__ == "__main__":
     create_shadertext(*sys.argv[1:6])

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ def create_buildinfo(outputdir, pymoldir="."):
 #define _PyMOL_BUILD_DATE %d
 #define _PYMOL_BUILD_GIT_SHA "%s"
         """
-            % (time.time(), sha),
+            % (int(os.environ.get('SOURCE_DATE_EPOCH', time.time())), sha),
             file=out,
         )
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.