### PR TITLE
Fix unknown wmclass in linux (missing dock icon)

### DIFF
--- a/modules/pmg_qt/pymol_qt_gui.py
+++ b/modules/pmg_qt/pymol_qt_gui.py
@@ -1223,9 +1223,8 @@ def execapp():
     window = PyMOLQtGUI()
     window.setWindowTitle("PyMOL")
 
-    # fix linux dash icon/missing wmclass
-    QtCore.QCoreApplication.setApplicationName("PyMOL")
-    QtGui.QGuiApplication.setDesktopFileName("org.pymol.PyMOL")
+    # fix gnome/wayland dash icon/missing wmclass
+    app.setDesktopFileName("org.pymol.PyMOL")
 
     @commandoverloaddecorator
     def viewport(w=-1, h=-1, _self=None):

--- a/modules/pmg_qt/pymol_qt_gui.py
+++ b/modules/pmg_qt/pymol_qt_gui.py
@@ -1223,6 +1223,10 @@ def execapp():
     window = PyMOLQtGUI()
     window.setWindowTitle("PyMOL")
 
+    # fix linux dash icon/missing wmclass
+    QtCore.QCoreApplication.setApplicationName("PyMOL")
+    QtGui.QGuiApplication.setDesktopFileName("org.pymol.PyMOL")
+
     @commandoverloaddecorator
     def viewport(w=-1, h=-1, _self=None):
         window.viewportsignal.emit(int(w), int(h))


### PR DESCRIPTION
Split from https://github.com/schrodinger/pymol-open-source/pull/400

On Linux, Pymol has a dash/dock gear icon and WMCLASS "python3", I've fixed this so now it exports the correct WMCLASS (which for gnome means that it is now able to find the correct icon).