### PR TITLE
fixing ci pipeline for python3.9 and python3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt-get update;
         sudo apt-get --no-install-recommends install
         catch2
-        cmake
         libfreetype6-dev
         libglew-dev
         libglm-dev
@@ -23,12 +22,6 @@ jobs:
         libnetcdf-dev
         libpng-dev
         libxml2-dev
-        python-is-python3
-        python3-biopython
-        python3-dev
-        python3-setuptools
-        python3-numpy
-        python3-pip
 
     - name: Install collada2gltf
       run: |
@@ -72,7 +65,7 @@ jobs:
       shell: cmd
       run: |-
         CALL %CONDA_ROOT%\\Scripts\\activate.bat
-        conda install -y -c conda-forge -c schrodinger python cmake libpng freetype pyside6 glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf biopython msgpack-python pip python-build libffi
+        conda install -y -c conda-forge -c schrodinger libpng freetype glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf libffi
 
     - name: Conda info
       shell: cmd
@@ -115,7 +108,7 @@ jobs:
         bash $CONDA_ROOT.sh -b -p $CONDA_ROOT
         export PATH="$CONDA_ROOT/bin:$PATH"
         conda config --set quiet yes
-        conda install -y -c conda-forge -c schrodinger python cmake libpng freetype pyside6 glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf biopython msgpack-python pip python-build
+        conda install -y -c conda-forge -c schrodinger python libpng freetype glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf
         conda info
 
     - name: Get additional sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       shell: cmd
       run: |-
         CALL %CONDA_ROOT%\\Scripts\\activate.bat
-        conda install -y -c conda-forge -c schrodinger python cmake libpng freetype pyside6 glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf biopython msgpack-python pip python-build
+        conda install -y -c conda-forge -c schrodinger python cmake libpng freetype pyside6 glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf biopython msgpack-python pip python-build libffi
 
     - name: Conda info
       shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,6 @@ jobs:
             python=${{ matrix.python-version }} `
             pip `
             catch2=2.13.3 `
-            cxx-compiler `
             collada2gltf `
             freetype `
             glew `
@@ -92,11 +91,9 @@ jobs:
             libpng `
             libxml2 `
             libnetcdf `
-            libffi
 
     - name: Get additional sources
       run: |
-        conda deactivate
         conda activate $env:CONDA_ENV_NAME
 
         git clone --depth 1 https://github.com/rcsb/mmtf-cpp.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,21 +7,30 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
-      run: >
-        sudo apt-get update;
-        sudo apt-get --no-install-recommends install
-        catch2
-        libfreetype6-dev
-        libglew-dev
-        libglm-dev
-        libmsgpack-dev
-        libnetcdf-dev
-        libpng-dev
-        libxml2-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install \
+            catch2 \
+            libfreetype6-dev \
+            libglew-dev \
+            libglm-dev \
+            libmsgpack-dev \
+            libnetcdf-dev \
+            libpng-dev \
+            libxml2-dev
 
     - name: Install collada2gltf
       run: |
@@ -31,7 +40,7 @@ jobs:
     - name: Get additional sources
       run: |
         git clone --depth 1 https://github.com/rcsb/mmtf-cpp.git
-        cp -R mmtf-cpp/include/mmtf* include/
+        cp -R mmtf-cpp/include/* include/
 
     - name: Build
       run: |
@@ -44,87 +53,123 @@ jobs:
       run: |
         pymol -ckqy testing/testing.py --run all
 
+
   build-Windows:
 
     runs-on: windows-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
     env:
-      CONDA_ROOT: ${{github.workspace}}\..\tmp\miniforge
-      MINIFORGE_EXEC: ${{github.workspace}}\..\tmp\miniforge.exe
+      CONDA_ENV_NAME: "testing_env"
 
     steps:
-    - uses: actions/checkout@v4.0.0
-    - name: Download Miniforge
-      shell: cmd
-      run: |-
-        if not exist %CONDA_ROOT% mkdir %CONDA_ROOT%
-        curl -L -o %MINIFORGE_EXEC% https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Miniforge3-24.11.0-0-Windows-x86_64.exe
-        start /wait %MINIFORGE_EXEC% /S /D=%CONDA_ROOT%
+    - uses: actions/checkout@v4
+
+    - name: Install Miniforge
+      run: |
+        choco install miniforge3
+
+    - name: Add conda to PATH
+      run: |
+        echo "$env:CONDA" | Out-File -Append -FilePath $env:GITHUB_PATH
+        echo "$env:CONDA\Scripts" | Out-File -Append -FilePath $env:GITHUB_PATH
 
     - name: Set up Miniforge
-      shell: cmd
-      run: |-
-        CALL %CONDA_ROOT%\\Scripts\\activate.bat
-        conda install -y -c conda-forge -c schrodinger libpng freetype glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf libffi
-
-    - name: Conda info
-      shell: cmd
-      run: |-
-        CALL %CONDA_ROOT%\\Scripts\\activate.bat
-        conda info
+      run: |
+        conda init powershell
+        conda create --name $env:CONDA_ENV_NAME -c conda-forge -c schrodinger `
+            python=${{ matrix.python-version }} `
+            pip `
+            catch2=2.13.3 `
+            cxx-compiler `
+            collada2gltf `
+            freetype `
+            glew `
+            glm `
+            libpng `
+            libxml2 `
+            libnetcdf `
+            libffi
 
     - name: Get additional sources
-      shell: cmd
       run: |
+        conda deactivate
+        conda activate $env:CONDA_ENV_NAME
+
         git clone --depth 1 https://github.com/rcsb/mmtf-cpp.git
-        cp -R mmtf-cpp/include/mmtf* %CONDA_ROOT%/Library/include/
+        Copy-Item -Recurse -Path mmtf-cpp/include\* -Destination "$env:CONDA_PREFIX\Library\include"
         git clone --depth 1 --single-branch --branch cpp_master https://github.com/msgpack/msgpack-c.git
-        cp -R msgpack-c/include/msgpack* %CONDA_ROOT%/Library/include/
+        Copy-Item -Recurse -Path msgpack-c/include\* -Destination "$env:CONDA_PREFIX\Library\include"
+        dir $env:CONDA_PREFIX\Library\include
 
     - name: Build PyMOL
-      shell: cmd
       run: |
-        CALL %CONDA_ROOT%\\Scripts\\activate.bat
+        conda activate $env:CONDA_ENV_NAME
         pip install -v --config-settings testing=True .[dev]
 
     - name: Test
-      shell: cmd
       run: |
-        CALL %CONDA_ROOT%\\Scripts\\activate.bat
-        pymol -ckqy testing\\testing.py --run all
+        conda activate $env:CONDA_ENV_NAME
+        pymol -ckqy testing\testing.py --run all
+
 
   build-MacOS:
 
     runs-on: macos-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
     env:
       CONDA_ROOT: "/tmp/miniforge"
+      CONDA_ENV_NAME: "testing_env"
 
     steps:
     - uses: actions/checkout@v4.0.0
-    - name: Set up Miniforge and Build
-      run: |-
+
+    - name: Download Miniforge
+      run: |
         curl -L -o $CONDA_ROOT.sh https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Miniforge3-MacOSX-x86_64.sh
         bash $CONDA_ROOT.sh -b -p $CONDA_ROOT
-        export PATH="$CONDA_ROOT/bin:$PATH"
-        conda config --set quiet yes
-        conda install -y -c conda-forge -c schrodinger python libpng freetype glew libxml2 catch2=2.13.3 glm libnetcdf collada2gltf
-        conda info
+
+    - name: Add conda to PATH
+      run: |
+        echo "${CONDA_ROOT}/bin" >> "$GITHUB_PATH"
+
+    - name: Set up Miniforge
+      run: |
+        conda create --name $CONDA_ENV_NAME -c conda-forge -c schrodinger \
+            python=${{ matrix.python-version }} \
+            pip \
+            catch2=2.13.3 \
+            collada2gltf \
+            freetype \
+            glew \
+            glm \
+            libpng \
+            libxml2 \
+            libnetcdf
 
     - name: Get additional sources
       run: |
+        source activate $CONDA_ENV_NAME
         git clone --depth 1 https://github.com/rcsb/mmtf-cpp.git
-        cp -R mmtf-cpp/include/mmtf* ${CONDA_ROOT}/include/
+        cp -R mmtf-cpp/include/* ${CONDA_PREFIX}/include/
         git clone --depth 1 --single-branch --branch cpp_master https://github.com/msgpack/msgpack-c.git
-        cp -R msgpack-c/include/msgpack* ${CONDA_ROOT}/include/
+        cp -R msgpack-c/include/* ${CONDA_PREFIX}/include/
 
     - name: Build PyMOL
-      run: |-
+      run: |
+        source activate $CONDA_ENV_NAME
         export MACOSX_DEPLOYMENT_TARGET=12.0
-        export PATH="$CONDA_ROOT/bin:$PATH"
         pip install -v --config-settings testing=True '.[dev]'
 
     - name: Test
-      run: |-
-        export PATH="$CONDA_ROOT/bin:$PATH"
+      run: |
+        source activate $CONDA_ENV_NAME
         pymol -ckqy testing/testing.py --run all
+

--- a/modules/pymol/shortcut.py
+++ b/modules/pymol/shortcut.py
@@ -12,7 +12,7 @@
 # -*
 # Z* -------------------------------------------------------------------
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 from collections import defaultdict
 from pymol import parsing
 
@@ -30,7 +30,7 @@ class Shortcut:
             if filter_leading_underscore
             else keywords
         )
-        self.shortcut: dict[str, str | int] = {}
+        self.shortcut: dict[str, Union[str, int]] = {}
         self.abbreviation_dict = defaultdict(list)
 
         for keyword in self.keywords:
@@ -41,7 +41,7 @@ class Shortcut:
     def __contains__(self, keyword: str) -> bool:
         return keyword in self.shortcut
 
-    def __getitem__(self, keyword: str) -> Optional[int | str]:
+    def __getitem__(self, keyword: str) -> Optional[Union[int, str]]:
         return self.shortcut.get(keyword)
 
     def __delitem__(self, keyword: str) -> None:
@@ -128,7 +128,7 @@ class Shortcut:
 
     def interpret(
         self, keyword: str, mode: bool = False
-    ) -> Optional[int | str | list[str]]:
+    ) -> Optional[Union[int, str, list[str]]]:
         """
         Returns None (no hit), str (one hit) or list (multiple hits)
 
@@ -172,7 +172,7 @@ class Shortcut:
 
     def auto_err(
         self, keyword: str, descrip: Optional[str] = None
-    ) -> Optional[int | str | list[str]]:
+    ) -> Optional[Union[int, str, list[str]]]:
         """
         Automatically raises an error if a keyword is unknown or ambiguous.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requires = [
 dev = [
   "pillow==11.1.0",
   "pytest==8.2.2",
+  "requests==2.32.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [
   {name = "Schrodinger", email = "pymol-users@lists.sourceforge.net"},
 ]
 dependencies = [
-  "biopython>=1.80",
   "numpy>=2.0",
 ]
 
@@ -22,13 +21,14 @@ dependencies = [
 build-backend = "backend"
 backend-path = ["_custom_build"]
 requires = [
-  "cmake>=3.30.5",
+  "cmake>=3.13.3",
   "numpy>=2.0",
   "setuptools>=69.2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "biopython>=1.80",
   "msgpack==1.0.8",
   "pillow==11.1.0",
   "PySide6==6.8.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires = [
 
 [project.optional-dependencies]
 dev = [
-  "pillow==10.3.0",
+  "pillow==11.1.0",
   "pytest==8.2.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
   {name = "Schrodinger", email = "pymol-users@lists.sourceforge.net"},
 ]
 dependencies = [
+  "biopython>=1.80",
   "numpy>=2.0",
 ]
 
@@ -21,13 +22,16 @@ dependencies = [
 build-backend = "backend"
 backend-path = ["_custom_build"]
 requires = [
+  "cmake>=3.30.5",
   "numpy>=2.0",
   "setuptools>=69.2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "msgpack==1.0.8",
   "pillow==11.1.0",
+  "PySide6==6.8.1",
   "pytest==8.2.2",
   "requests==2.32.3",
 ]

--- a/testing/tests/api/test_shortcut.py
+++ b/testing/tests/api/test_shortcut.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pytest
 
 from pymol.shortcut import Shortcut
@@ -48,7 +50,7 @@ def test_all_keywords(sc: Shortcut):
     ],
 )
 def test_full_prefix_hits(
-    sc: Shortcut, prefixs: list[str], expected_result: str | list[str]
+    sc: Shortcut, prefixs: list[str], expected_result: Union[str, list[str]]
 ):
     for prefix in prefixs:
         result = sc.interpret(prefix)


### PR DESCRIPTION
- [adding libffi to windows ci pipeline](https://github.com/schrodinger/pymol-open-source/pull/435/commits/5db731467192d0a2e07720b5c1f3d894c39afbf0) - I have encountered an error in CI for the Windows platform([example](https://github.com/schrodinger/pymol-open-source/actions/runs/13354211427/job/37294680115)). 
For more information on the solution, check [this link](https://stackoverflow.com/questions/73458524/importerror-dll-load-failed-while-importing-ctypes-the-specified-module-coul/76791146#76791146).
- [bump pillow version](https://github.com/schrodinger/pymol-open-source/pull/435/commits/2147ef1e9d128d4c066bbafc920968e898065b41) - The pipelines for macOS and Windows are failing because they are using Python 3.13 with old version of PIL, which is supported only by the latest version(11). Also, it's the last version that supports Python 3.9. [example of error](https://github.com/schrodinger/pymol-open-source/actions/runs/13437935620/job/37544739657?pr=435). [The Issue in pillow repo](https://github.com/python-pillow/Pillow/issues/8075).


![изображение](https://github.com/user-attachments/assets/5efeb219-508f-4598-8483-ad02a35dbae0)
 
- [refactoring testLoadPWG](https://github.com/schrodinger/pymol-open-source/pull/435/commits/2fe1c167881c330d712e93fee7159c0ff6d25c96) - In an effort to find the root cause of the issue, I have updated the testLoadPWG test to make it easier to understand.
- [removing usage of cgi lib](https://github.com/schrodinger/pymol-open-source/pull/435/commits/1306de6c56cb37999409b1ebc9c3d6ff29fb021d) - [The cgi module has been removed from the std since Python 3.13](https://docs.python.org/3/library/cgi.html)
This module is quite old, and I have not had to work with it before. I would appreciate any assistance with testing it.
Additionally, the use of cgi can still be found in [examples](https://github.com/schrodinger/pymol-open-source/blob/27c28cb4b3a7590895437c15c428784b5b455125/examples/devel/webgui02.py#L10)
- [moving all pyton dependencies from github/workflow to pyproject.toml](https://github.com/schrodinger/pymol-open-source/pull/435/commits/df8de6867409fb9bdc137910f94af59e6679e243) - It is no longer necessary to install Python dependencies via conda. Instead, it is recommended to store them in a pyproject.toml file.
- [adding strategy for python versions](https://github.com/schrodinger/pymol-open-source/pull/435/commits/5b83fe9bfe0fdf118f5a004dfad8bdee3047471f) - The readme file states that the project is compatible with all versions of Python starting from 3.9, however, this has not yet been tested.
- [fixing type annotation for python3.9](https://github.com/schrodinger/pymol-open-source/pull/435/commits/3ed37a13d3ca3eefc0a278b60636a5bd0d129ef9) - Fixing type annotations to support Python 3.9
