### PR TITLE
Attempt to detect delocalized atoms

### DIFF
--- a/layer1/P.cpp
+++ b/layer1/P.cpp
@@ -615,9 +615,9 @@ static T const* get_member_pointer(S const* instance, size_t offset)
  * Should be equivalent to:
  *   OBAtom::GetExplicitValence() [Open Babel 3.0]
  */
-float getExplicitValence(ObjectMolecule const* obj, size_t atm)
+unsigned getExplicitValence(ObjectMolecule const* obj, size_t atm)
 {
-  float value = 0;
+  unsigned value = 0;
 
   for (auto const& item : AtomNeighbors(obj, atm)) {
     int const order = obj->Bond[item.bond].order;

--- a/layer1/P.cpp
+++ b/layer1/P.cpp
@@ -615,9 +615,9 @@ static T const* get_member_pointer(S const* instance, size_t offset)
  * Should be equivalent to:
  *   OBAtom::GetExplicitValence() [Open Babel 3.0]
  */
-static int getExplicitValence(ObjectMolecule const* obj, size_t atm)
+float getExplicitValence(ObjectMolecule const* obj, size_t atm)
 {
-  int value = 0;
+  float value = 0;
 
   for (auto const& item : AtomNeighbors(obj, atm)) {
     int const order = obj->Bond[item.bond].order;
@@ -643,7 +643,7 @@ static int getExplicitValence(ObjectMolecule const* obj, size_t atm)
  *   RDKit::Atom::getDegree()
  *   OBAtom::GetExplicitDegree() [Open Babel 3.0]
  */
-static unsigned getExplicitDegree(ObjectMolecule const* obj, size_t atm)
+unsigned getExplicitDegree(ObjectMolecule const* obj, size_t atm)
 {
   return AtomNeighbors(obj, atm).size();
 }

--- a/layer1/P.h
+++ b/layer1/P.h
@@ -56,7 +56,7 @@ Z* -------------------------------------------------------------------
 #define cPRunType_alter_state    2
 #define cPRunType_label          3
 
-float getExplicitValence(ObjectMolecule const* obj, size_t atm);
+unsigned getExplicitValence(ObjectMolecule const* obj, size_t atm);
 unsigned getExplicitDegree(ObjectMolecule const* obj, size_t atm);
 
 int PLabelExprUsesVariable(PyMOLGlobals * G, const char *expr, const char *var);

--- a/layer1/P.h
+++ b/layer1/P.h
@@ -56,6 +56,8 @@ Z* -------------------------------------------------------------------
 #define cPRunType_alter_state    2
 #define cPRunType_label          3
 
+float getExplicitValence(ObjectMolecule const* obj, size_t atm);
+unsigned getExplicitDegree(ObjectMolecule const* obj, size_t atm);
 
 int PLabelExprUsesVariable(PyMOLGlobals * G, const char *expr, const char *var);
 

--- a/layer3/Selector.cpp
+++ b/layer3/Selector.cpp
@@ -7503,7 +7503,7 @@ static int SelectorSelect0(PyMOLGlobals * G, EvalElem * passed_base)
       for (a = cNDummyAtoms; a < I->Table.size(); a++) {
         const auto* m = I->Obj[I->Table[a].model];
         const auto at_i = I->Table[a].atom;
-        const auto deloc = getExplicitDegree(m, at_i) / getExplicitValence(m, at_i);
+        const auto deloc = (float) getExplicitDegree(m, at_i) / (float) getExplicitValence(m, at_i);
         base[0].sele[a] = floor(deloc) != deloc;
       }
       break;

--- a/layer3/Selector.cpp
+++ b/layer3/Selector.cpp
@@ -54,6 +54,7 @@ Z* -------------------------------------------------------------------
 #include"OVLexicon.h"
 #include"Parse.h"
 
+#include "P.h"
 #include"ListMacros.h"
 
 #ifdef _PYMOL_IP_PROPERTIES
@@ -410,6 +411,7 @@ static int SelectorGetObjAtmOffset(
 #define SELE_LABs ( 0x5500 | STYP_SEL1 | 0x80 )
 #define SELE_PROz ( 0x5600 | STYP_SEL0 | 0x90 )
 #define SELE_NUCz ( 0x5700 | STYP_SEL0 | 0x90 )
+#define SELE_DESz ( 0x5800 | STYP_SEL0 | 0x90 )
 
 #define SEL_PREMAX 0x8
 
@@ -603,6 +605,9 @@ static WordKeyValue Keyword[] = {
 
   {"acceptors", SELE_ACCz},
   {"acc.", SELE_ACCz},
+
+  {"delocalized", SELE_DESz},
+  {"deloc.", SELE_DESz},
 
   {"pepseq", SELE_PEPs},
   {"ps.", SELE_PEPs},
@@ -7471,7 +7476,7 @@ static int SelectorSelect0(PyMOLGlobals * G, EvalElem * passed_base)
   case SELE_HBDs:
   case SELE_DONz:
   case SELE_ACCz:
-
+  case SELE_DESz:
     {
       /* first, verify chemistry for all atoms... */
       ObjectMolecule *lastObj = nullptr, *obj;
@@ -7494,7 +7499,14 @@ static int SelectorSelect0(PyMOLGlobals * G, EvalElem * passed_base)
       for(a = cNDummyAtoms; a < I->Table.size(); a++)
         base[0].sele[a] = I->Obj[I->Table[a].model]->AtomInfo[I->Table[a].atom].hb_donor;
       break;
-
+    case SELE_DESz:
+      for (a = cNDummyAtoms; a < I->Table.size(); a++) {
+        const auto* m = I->Obj[I->Table[a].model];
+        const auto at_i = I->Table[a].atom;
+        const auto deloc = getExplicitDegree(m, at_i) / getExplicitValence(m, at_i);
+        base[0].sele[a] = floor(deloc) != deloc;
+      }
+      break;
     }
     break;
   case SELE_NONz:

--- a/testing/tests/api/querying.py
+++ b/testing/tests/api/querying.py
@@ -29,6 +29,13 @@ class TestQuerying(testing.PyMOLTestCase):
         # used in many tests
         pass
 
+    def testSelectDelocalized(self):
+        cmd.fragment("phe")
+        count = cmd.count_atoms("deloc.")
+        self.assertEqual(count, 8)
+        count = cmd.count_atoms("delocalized")
+        self.assertEqual(count, 8)
+
     def testCountFrames(self):
         self.assertEqual(cmd.count_frames(), 0)
         cmd.pseudoatom("m1")


### PR DESCRIPTION
Hi. This is my attempt to support the selection of delocalized atoms. I copy the following comment to turn potential limitations explicit.

```C++
      // simple rule which gets all aromatic C atoms right, but can
      // be wrong for example for neutral aromatic N atoms with degree 3 or
      // for neutral carboxy O atoms which PyMOL also assigns bond oder 4.
```

I want also to detect aromatic rings. Should I do proceed?