### PR TITLE
use Catch2 version 3.x

### DIFF
--- a/layerCTest/Test.cpp
+++ b/layerCTest/Test.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <iostream>
 #define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "Test.h"
 #include "TestCmdTest2.h"
 

--- a/layerCTest/Test.h
+++ b/layerCTest/Test.h
@@ -11,7 +11,7 @@
 #include "PConv.h"
 #include "pymol/type_traits.h"
 #include "pymol/algorithm.h"
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 namespace pymol {
 

--- a/layerCTest/Test_CCrystal.cpp
+++ b/layerCTest/Test_CCrystal.cpp
@@ -6,12 +6,12 @@
 TEST_CASE("cryst-misc", "[CCrystal]")
 {
   CCrystal cryst(nullptr);
-  REQUIRE(cryst.dims()[0] == Approx(1.0));
-  REQUIRE(cryst.dims()[1] == Approx(1.0));
-  REQUIRE(cryst.dims()[2] == Approx(1.0));
-  REQUIRE(cryst.angles()[0] == Approx(90.0));
-  REQUIRE(cryst.angles()[1] == Approx(90.0));
-  REQUIRE(cryst.angles()[2] == Approx(90.0));
+  REQUIRE(cryst.dims()[0] == Catch::Approx(1.0));
+  REQUIRE(cryst.dims()[1] == Catch::Approx(1.0));
+  REQUIRE(cryst.dims()[2] == Catch::Approx(1.0));
+  REQUIRE(cryst.angles()[0] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[1] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[2] == Catch::Approx(90.0));
   REQUIRE(is_identityf(3, cryst.fracToReal()));
   REQUIRE(is_identityf(3, cryst.realToFrac()));
 
@@ -20,12 +20,12 @@ TEST_CASE("cryst-misc", "[CCrystal]")
   float const f2r_458[] = {4, 0, 0, 0, 5, 0, 0, 0, 8};
   float const r2f_458[] = {0.25, 0, 0, 0, 0.2, 0, 0, 0, 0.125};
 
-  REQUIRE(cryst.dims()[0] == Approx(4.0));
-  REQUIRE(cryst.dims()[1] == Approx(5.0));
-  REQUIRE(cryst.dims()[2] == Approx(8.0));
-  REQUIRE(cryst.angles()[0] == Approx(90.0));
-  REQUIRE(cryst.angles()[1] == Approx(90.0));
-  REQUIRE(cryst.angles()[2] == Approx(90.0));
+  REQUIRE(cryst.dims()[0] == Catch::Approx(4.0));
+  REQUIRE(cryst.dims()[1] == Catch::Approx(5.0));
+  REQUIRE(cryst.dims()[2] == Catch::Approx(8.0));
+  REQUIRE(cryst.angles()[0] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[1] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[2] == Catch::Approx(90.0));
   REQUIRE(is_allclosef(3, cryst.fracToReal(), 3, f2r_458, 3));
   REQUIRE(is_allclosef(3, cryst.realToFrac(), 3, r2f_458, 3));
 
@@ -36,17 +36,17 @@ TEST_CASE("cryst-misc", "[CCrystal]")
   float const r2f_458_607080[] = {
       0.25, -0.0441, -0.0796, 0., 0.2031, -0.11, 0., 0., 0.1513};
 
-  REQUIRE(cryst.dims()[0] == Approx(4.0));
-  REQUIRE(cryst.dims()[1] == Approx(5.0));
-  REQUIRE(cryst.dims()[2] == Approx(8.0));
-  REQUIRE(cryst.angles()[0] == Approx(60.0));
-  REQUIRE(cryst.angles()[1] == Approx(70.0));
-  REQUIRE(cryst.angles()[2] == Approx(80.0));
+  REQUIRE(cryst.dims()[0] == Catch::Approx(4.0));
+  REQUIRE(cryst.dims()[1] == Catch::Approx(5.0));
+  REQUIRE(cryst.dims()[2] == Catch::Approx(8.0));
+  REQUIRE(cryst.angles()[0] == Catch::Approx(60.0));
+  REQUIRE(cryst.angles()[1] == Catch::Approx(70.0));
+  REQUIRE(cryst.angles()[2] == Catch::Approx(80.0));
   REQUIRE(is_allclosef(3, cryst.fracToReal(), 3, f2r_458_607080, 3, 1e-3));
   REQUIRE(is_allclosef(3, cryst.realToFrac(), 3, r2f_458_607080, 3, 1e-3));
 
   // volume
-  REQUIRE(cryst.unitCellVolume() == Approx(130.20694));
+  REQUIRE(cryst.unitCellVolume() == Catch::Approx(130.20694));
 
   // cross-check
   REQUIRE(!is_identityf(3, cryst.fracToReal()));
@@ -54,34 +54,34 @@ TEST_CASE("cryst-misc", "[CCrystal]")
 
   // copy
   auto crystcopy = cryst;
-  REQUIRE(crystcopy.dims()[0] == Approx(4.0));
-  REQUIRE(crystcopy.dims()[1] == Approx(5.0));
-  REQUIRE(crystcopy.dims()[2] == Approx(8.0));
-  REQUIRE(crystcopy.angles()[0] == Approx(60.0));
-  REQUIRE(crystcopy.angles()[1] == Approx(70.0));
-  REQUIRE(crystcopy.angles()[2] == Approx(80.0));
+  REQUIRE(crystcopy.dims()[0] == Catch::Approx(4.0));
+  REQUIRE(crystcopy.dims()[1] == Catch::Approx(5.0));
+  REQUIRE(crystcopy.dims()[2] == Catch::Approx(8.0));
+  REQUIRE(crystcopy.angles()[0] == Catch::Approx(60.0));
+  REQUIRE(crystcopy.angles()[1] == Catch::Approx(70.0));
+  REQUIRE(crystcopy.angles()[2] == Catch::Approx(80.0));
   REQUIRE(is_allclosef(3, crystcopy.fracToReal(), 3, f2r_458_607080, 3, 1e-3));
   REQUIRE(is_allclosef(3, crystcopy.realToFrac(), 3, r2f_458_607080, 3, 1e-3));
 
   // reset
   cryst = CCrystal(nullptr);
-  REQUIRE(cryst.dims()[0] == Approx(1.0));
-  REQUIRE(cryst.dims()[1] == Approx(1.0));
-  REQUIRE(cryst.dims()[2] == Approx(1.0));
-  REQUIRE(cryst.angles()[0] == Approx(90.0));
-  REQUIRE(cryst.angles()[1] == Approx(90.0));
-  REQUIRE(cryst.angles()[2] == Approx(90.0));
+  REQUIRE(cryst.dims()[0] == Catch::Approx(1.0));
+  REQUIRE(cryst.dims()[1] == Catch::Approx(1.0));
+  REQUIRE(cryst.dims()[2] == Catch::Approx(1.0));
+  REQUIRE(cryst.angles()[0] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[1] == Catch::Approx(90.0));
+  REQUIRE(cryst.angles()[2] == Catch::Approx(90.0));
   REQUIRE(is_identityf(3, cryst.fracToReal()));
   REQUIRE(is_identityf(3, cryst.realToFrac()));
 
   // set frac-to-real
   cryst.setFracToReal(f2r_458_607080);
-  REQUIRE(cryst.dims()[0] == Approx(4.0));
-  REQUIRE(cryst.dims()[1] == Approx(5.0));
-  REQUIRE(cryst.dims()[2] == Approx(8.0));
-  REQUIRE(cryst.angles()[0] == Approx(60.0));
-  REQUIRE(cryst.angles()[1] == Approx(70.0));
-  REQUIRE(cryst.angles()[2] == Approx(80.0));
+  REQUIRE(cryst.dims()[0] == Catch::Approx(4.0));
+  REQUIRE(cryst.dims()[1] == Catch::Approx(5.0));
+  REQUIRE(cryst.dims()[2] == Catch::Approx(8.0));
+  REQUIRE(cryst.angles()[0] == Catch::Approx(60.0));
+  REQUIRE(cryst.angles()[1] == Catch::Approx(70.0));
+  REQUIRE(cryst.angles()[2] == Catch::Approx(80.0));
   REQUIRE(is_allclosef(3, cryst.fracToReal(), 3, f2r_458_607080, 3, 1e-3));
   REQUIRE(is_allclosef(3, cryst.realToFrac(), 3, r2f_458_607080, 3, 1e-3));
 }

--- a/layerCTest/Test_CifFile.cpp
+++ b/layerCTest/Test_CifFile.cpp
@@ -99,8 +99,8 @@ TEST_CASE("misc", "[CifFile]")
   // type deducted from default value
 
   REQUIRE(data->get_opt("_cat2.key1")->as(0, 99) / 3 == 3); // int
-  REQUIRE(data->get_opt("_cat2.key1")->as(0, 99) / 3 != Approx(10. / 3.)); // int
-  REQUIRE(data->get_opt("_cat2.key1")->as(0, 99.) / 3 == Approx(10. / 3.)); // double
+  REQUIRE(data->get_opt("_cat2.key1")->as(0, 99) / 3 != Catch::Approx(10. / 3.)); // int
+  REQUIRE(data->get_opt("_cat2.key1")->as(0, 99.) / 3 == Catch::Approx(10. / 3.)); // double
   REQUIRE(data->get_opt("_cat2.key2")->as(0, 99.) == 0.1);
   REQUIRE(data->get_opt("_cat2.key3")->as(0, 99.f) == 99.f);
   REQUIRE(data->get_opt("_cat2.key4")->as(0, std::string("type deducted")) == "foo");
@@ -142,10 +142,10 @@ TEST_CASE("misc", "[CifFile]")
 
   // float parsing
 
-  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float1")->as<float>() == Approx(1230.f));
-  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float1")->as<double>() == Approx(1230.00000));
-  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float2")->as<double>() == Approx(12.3400000));
-  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float3")->as<double>() == Approx(1.23456789));
+  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float1")->as<float>() == Catch::Approx(1230.f));
+  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float1")->as<double>() == Catch::Approx(1230.00000));
+  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float2")->as<double>() == Catch::Approx(12.3400000));
+  REQUIRE(blocks.find("baz")->second.get_opt("_typed_float3")->as<double>() == Catch::Approx(1.23456789));
 }
 
 // vi:sw=2:expandtab

--- a/layerCTest/Test_TTT.cpp
+++ b/layerCTest/Test_TTT.cpp
@@ -126,10 +126,10 @@ TEST_CASE("TTT Matrix Rotate and Get Rotation", "[TTT Matrix]")
   ttt.rotate(degRot, axis);
   ttt.rotate(degRot, axis2);
   auto rot = ttt.getRotation();
-  REQUIRE(rot[0] == Approx(0.5f));
-  REQUIRE(rot[1] == Approx(0.5f));
-  REQUIRE(rot[2] == Approx(0.5f));
-  REQUIRE(rot[3] == Approx(0.5f));
+  REQUIRE(rot[0] == Catch::Approx(0.5f));
+  REQUIRE(rot[1] == Catch::Approx(0.5f));
+  REQUIRE(rot[2] == Catch::Approx(0.5f));
+  REQUIRE(rot[3] == Catch::Approx(0.5f));
 }
 
 TEST_CASE("TTT Matrix - TTT Matrix Multiply", "[TTT Matrix]")
@@ -248,19 +248,19 @@ TEST_CASE("TTT Lerp", "[TTT Matrix]")
   auto rot = lerped_ttt.getRotation();
   auto post = lerped_ttt.getPostTranslation();
 
-  REQUIRE(pre[0] == Approx(-150.0f));
-  REQUIRE(pre[1] == Approx(-250.0f));
-  REQUIRE(pre[2] == Approx(-350.0f));
-  REQUIRE(pre[0] == Approx(-150.0f));
-  REQUIRE(pre[1] == Approx(-250.0f));
-  REQUIRE(pre[2] == Approx(-350.0f));
-  REQUIRE(rot[0] == Approx(0.40825f));
-  REQUIRE(rot[1] == Approx(0.40825f));
-  REQUIRE(rot[2] == Approx(0.0f));
-  REQUIRE(rot[3] == Approx(0.40825f * 2.0f));
-  REQUIRE(post[0] == Approx( 165.0f));
-  REQUIRE(post[1] == Approx( 275.0f));
-  REQUIRE(post[2] == Approx( 385.0f));
+  REQUIRE(pre[0] == Catch::Approx(-150.0f));
+  REQUIRE(pre[1] == Catch::Approx(-250.0f));
+  REQUIRE(pre[2] == Catch::Approx(-350.0f));
+  REQUIRE(pre[0] == Catch::Approx(-150.0f));
+  REQUIRE(pre[1] == Catch::Approx(-250.0f));
+  REQUIRE(pre[2] == Catch::Approx(-350.0f));
+  REQUIRE(rot[0] == Catch::Approx(0.40825f));
+  REQUIRE(rot[1] == Catch::Approx(0.40825f));
+  REQUIRE(rot[2] == Catch::Approx(0.0f));
+  REQUIRE(rot[3] == Catch::Approx(0.40825f * 2.0f));
+  REQUIRE(post[0] == Catch::Approx( 165.0f));
+  REQUIRE(post[1] == Catch::Approx( 275.0f));
+  REQUIRE(post[2] == Catch::Approx( 385.0f));
 }
 
 TEST_CASE("TTT Serialize To", "[TTT Matrix]")

--- a/setup.py
+++ b/setup.py
@@ -637,6 +637,7 @@ if not options.glut:
 if options.testing:
     pymol_src_dirs += ["layerCTest"]
     def_macros += [("_PYMOL_CTEST", None)]
+    libs += ["Catch2"]
 
 if options.openvr:
     def_macros += [("_PYMOL_OPENVR", None)]


### PR DESCRIPTION
in 2022, Catch2 got a major update to v3.,slightly incompatible to v2.  recent gentoo, ubuntu, opensuse, fedora have v3.  while opensuse and fedora also provide a v2, gentoo and ubuntu 24.04 do not.  ubuntu 22.04 provides v2 only.
anyhow: this PR should have the pymol source changes neccessary to migrate to catch2 v3.