### PR TITLE
Fix declare_command on Windows

### DIFF
--- a/modules/pymol/commanding.py
+++ b/modules/pymol/commanding.py
@@ -13,6 +13,7 @@
 #Z* -------------------------------------------------------------------
 
 from pymol.shortcut import Shortcut
+from pymol.parser import __file__ as _parser_filename
 
 if True:
 
@@ -656,11 +657,10 @@ SEE ALSO
         # Inner function that will be callable every time the command is executed
         @wraps(function)
         def inner(*args, **kwargs):
-            frame = traceback.format_stack()[-2]
-            caller = frame.split("\"", maxsplit=2)[1]
+            caller = traceback.extract_stack(limit=2)[0].filename
 
             # It was called from command line or pml script, so parse arguments
-            if caller.endswith("pymol/parser.py"):
+            if caller == _parser_filename:
                 kwargs = {**kwargs_, **kwargs, **dict(zip(args2_, args))}
                 kwargs.pop("_self", None)
                 for arg in kwargs.copy():


### PR DESCRIPTION
The `declare_command` unit tests fail on Windows, probably because of the forward slash in the filename check. Fixed by comparing with `pymol.parser.__file__` instead.

Also use `traceback.extract_stack` instead of `traceback.format_stack` to avoid parsing the filename from a string.