### PR TITLE
Defer sort and index extension when loading xyz str

### DIFF
--- a/layer2/ObjectMolecule.cpp
+++ b/layer2/ObjectMolecule.cpp
@@ -8645,10 +8645,11 @@ ObjectMolecule *ObjectMoleculeReadStr(PyMOLGlobals * G, ObjectMolecule * I,
       if(ok && isNew)
         ok &= ObjectMoleculeConnect(I, cset, connect);
 
-      if (ok)
-	ok &= ObjectMoleculeExtendIndices(I, frame);
-      if (ok)
-	ok &= ObjectMoleculeSort(I);
+      if (ok) {
+        if (I->DiscreteFlag) {
+          ok &= ObjectMoleculeExtendIndices(I, frame);
+        }
+      }
 
       deferred_tasks = true;
       successCnt++;
@@ -8677,6 +8678,10 @@ ObjectMolecule *ObjectMoleculeReadStr(PyMOLGlobals * G, ObjectMolecule * I,
     }
   }
   if(deferred_tasks && I) {     /* defer time-consuming tasks until all states have been loaded */
+    if (!I->DiscreteFlag) {
+      ObjectMoleculeExtendIndices(I, cStateAll);
+    }
+    ObjectMoleculeSort(I);
     if (set_formal_charges){
       ObjectMoleculeMOL2SetFormalCharges(G, I);
     }


### PR DESCRIPTION
Anytime a set of coordinates are loaded in with `ObjectMoleculeReadStr`, a molecule sort and index extension is performed for each `CoordSet` that's added. These can likely just be deferred until after all are loaded. I haven't tested the `discrete` case, so for now, discrete sets will behave the same.


Fixes #465 