### PR TITLE
Validate selections in `get_object_list()``

### DIFF
--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -137,8 +137,12 @@ DESCRIPTION
     something to do with querying the objects covered by a selection.
     '''
         selection = selector.process(selection)
+        if selection.strip() == "":
+            raise pymol.CmdException("Empty selections or containing only spaces are invalid.")
         with _self.lockcm:
             r = _cmd.get_object_list(_self._COb,str(selection))
+            if r is None:
+                raise pymol.CmdException('Invalid selection.')
             if not quiet:
                 if(is_list(r)):
                     print(" get_object_list: ",str(r))

--- a/testing/tests/api/querying.py
+++ b/testing/tests/api/querying.py
@@ -339,6 +339,9 @@ class TestQuerying(testing.PyMOLTestCase):
         cmd.ramp_new('ramp1', 'none')  # non-molecular object
         self.assertEqual(cmd.get_object_list(), ['gly', 'cys'])
         self.assertEqual(cmd.get_object_list('elem S'), ['cys'])
+        for sele in ['', ' ', 'www.@']:
+            with self.assertRaises(CmdException):
+                cmd.get_object_list(sele)
 
     @testing.requires_version('1.6')
     def testGetObjectMatrix(self):


### PR DESCRIPTION
Raise exceptions for empty or invalid inputs.

May fix #478.