### PR TITLE
Error propagation for cmd.get_object_list()

### DIFF
--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -4067,8 +4067,7 @@ static pymol::Result<PyObject*> _getObjectMoleculeNamePyList(
     PyMOLGlobals* G, char const* sele)
 {
   if (!sele[0]) {
-    // preserve non-error legacy behavior: Empty selection returns None
-    return APIAutoNone(nullptr);
+    return PyList_New(0);
   }
   auto tmpsele1 = SelectorTmp::make(G, sele);
   p_return_if_error(tmpsele1);

--- a/testing/tests/api/querying.py
+++ b/testing/tests/api/querying.py
@@ -344,9 +344,8 @@ class TestQuerying(testing.PyMOLTestCase):
         self.assertEqual(cmd.get_object_list(' '), [])
         # empty string is a falsy value
         self.assertTrue(not cmd.get_object_list(''))
-        # empty string is a silent None
-        # https://github.com/schrodinger/pymol-open-source/issues/478
-        self.assertTrue(cmd.get_object_list('') is None)
+        # empty string is empty selection
+        self.assertEqual(cmd.get_object_list(''), [])
 
     def testGetObjectList__invalid_selection(self):
         self.assertRaises(CmdException, cmd.get_object_list, 'invalid_selection_name')


### PR DESCRIPTION
Propagates `cmd.get_object_list()` errors from C++ to Python.

~~Does not change the empty string behavior yet~~
Changes the empty string behavior (#478)

Alternative to https://github.com/schrodinger/pymol-open-source/pull/481

_Note: Suggest **not** to squash, second commit is deliberate to isolate the empty string behavior change_