### PR TITLE
Fix PytestUnraisableExceptionWarning with cmd.fragment()

### DIFF
--- a/layer2/ObjectMolecule.cpp
+++ b/layer2/ObjectMolecule.cpp
@@ -7252,6 +7252,8 @@ ObjectMolecule *ObjectMoleculeLoadChemPyModel(PyMOLGlobals * G,
           }
         }
         Py_DECREF(mol);
+      } else if (PyErr_Occurred() == PyExc_AttributeError) {
+        PyErr_Clear();
       }
       if(PyObject_HasAttrString(model, "spheroid") &&
          PyObject_HasAttrString(model, "spheroid_normals")) {


### PR DESCRIPTION
pytest reports `PytestUnraisableExceptionWarning` in `tests/api/build.py::TestNucBuilder`.

Minimal example is to call `cmd.fragment("gtp")`.

```
$ python -c 'from pymol import cmd;cmd.fragment("gtp")'
Exception ignored in PyObject_HasAttrString(); consider using PyObject_HasAttrStringWithError(), PyObject_GetOptionalAttrString() or PyObject_GetAttrString():
Traceback (most recent call last):
  File "/d2/bld/env-open-source-3-1-master/lib/python3.13/site-packages/pymol/importing.py", line 205, in load_object
    r = _cmd.load_object(_self._COb,str(name),object,int(state)-1,
AttributeError: 'Indexed' object has no attribute 'molecule'
```

Since 'molecule' seems to be an optional member of the chempy `Indexed` object, the `AttributeError` can be deliberately ignored.