### PR TITLE
fix: update launch script handling for mingw-w64/msys2 on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -508,23 +508,28 @@ class install_pymol(install):
 
         with open(launch_script, "w") as out:
             if WIN:
-                # paths relative to launcher, if possible
-                try:
-                    python_exe = "%~dp0\\" + os.path.relpath(
-                        python_exe, self.install_scripts
-                    )
-                except ValueError:
-                    pass
-                try:
-                    pymol_file = "%~dp0\\" + os.path.relpath(
-                        pymol_file, self.install_scripts
-                    )
-                except ValueError:
-                    pymol_file = os.path.abspath(pymol_file)
-
                 if not self.pymol_path_is_default:
                     out.write(f"set PYMOL_PATH={pymol_path}" + os.linesep)
-                out.write('"%s" "%s"' % (python_exe, pymol_file))
+
+                if is_mingw:
+                    python_exe = "%~dp0\\python.exe"
+                    out.write('"%s" -m pymol' % python_exe)
+                else:
+                    # paths relative to launcher, if possible
+                    try:
+                        python_exe = "%~dp0\\" + os.path.relpath(
+                            python_exe, self.install_scripts
+                        )
+                    except ValueError:
+                        pass
+                    try:
+                        pymol_file = "%~dp0\\" + os.path.relpath(
+                            pymol_file, self.install_scripts
+                        )
+                    except ValueError:
+                        pymol_file = os.path.abspath(pymol_file)
+                    out.write('"%s" "%s"' % (python_exe, pymol_file))
+
                 out.write(" %*" + os.linesep)
             else:
                 out.write("#!/bin/sh" + os.linesep)


### PR DESCRIPTION
The current `pymol.bat` launcher generation on Windows attempts to write relative paths to `python.exe` and the PyMOL module. However, when the build directory differs from the installation directory (e.g., during package repackaging for MSYS2/mingw-w64), this results in incorrect, hardcoded absolute paths that break the launcher:

```bat
"%~dp0\../../../../../../../../../M/msys64/ucrt64/bin/python.exe" "%~dp0\../../../../../../../../../M/msys64/ucrt64/lib/python3.12/site-packages/pymol/__init__.py" %*
```

This PR fixes the issue specifically for the mingw-w64/msys2 building and packaging by simplifying the launcher logic. Instead of computing fragile relative paths, it now uses the reliable invocation, which ensures the launcher always uses the Python interpreter adjacent to the batch file:

```bat
"%~dp0\python.exe" -m pymol %*
```

With the protection of if clause, it will not affect non-mingw/msys2 behavior.

Tested on my own machine.