### PR TITLE
fix(executive): reject placeholder unit cells in symexp

### DIFF
--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -14283,6 +14283,11 @@ void ExecutiveSymExp(PyMOLGlobals* G, const char* name, const char* oname,
     return;
   }
 
+  if (sym->Crystal.isSuspicious()) {
+    ErrMessage(G, __func__, "Invalid or placeholder unit cell");
+    return;
+  }
+
   int const nsymmat = sym->getNSymMat();
 
   if (nsymmat < 1) {

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -14249,6 +14249,10 @@ static std::string make_symexp_segi_label(int a, int x, int y, int z)
  * of +/-1 unit cells. The cutoff applies across states, so a symmetry atom will
  * be included if it's within any atom of @a s1 in any state.
  *
+ * Reports an error and creates no objects if @a oname has no symmetry, or if
+ * its unit cell is suspicious (see CCrystal::isSuspicious()), like the
+ * placeholder cells that encode missing symmetry.
+ *
  * @param name Prefix for new objects
  * @param oname Object to replicate
  * @param s1 Atom selection (for cutoff)

--- a/modules/pymol/creating.py
+++ b/modules/pymol/creating.py
@@ -922,6 +922,11 @@ NOTES
     The newly objects are labeled using the prefix provided along with
     their crystallographic symmetry operation and translation.
 
+    A valid crystallographic unit cell is required. Objects without
+    symmetry, or with a placeholder unit cell (e.g. the 1 x 1 x 1
+    Angstrom "P 1" cell that some cryo-EM entries use to encode missing
+    symmetry), are not expanded and an error is reported instead.
+
 SEE ALSO
 
     load

--- a/testing/tests/api/creating.py
+++ b/testing/tests/api/creating.py
@@ -318,6 +318,14 @@ class TestCreating(testing.PyMOLTestCase):
         self.assertEqual(segis["s03000000"], set(["D000" if segi else ""]))
         self.assertEqual(segis["s04000000"], set(["E000" if segi else ""]))
 
+    def testSymexpPlaceholderUnitCell(self):
+        cmd.pseudoatom('m1')
+        cmd.set_symmetry('m1', 1, 1, 1, 90, 90, 90, 'P 1')
+
+        cmd.symexp('s', 'm1', 'm1', 5)
+
+        self.assertEqual(cmd.get_object_list(), ['m1'])
+
     def testFragment(self):
         frag_name = "ala"
         cmd.fragment(frag_name)


### PR DESCRIPTION
## Summary

Fixes #509 by preventing `symexp` from generating symmetry mates for invalid or placeholder unit cells, such as the 1 × 1 × 1 Å `P 1` cells in 8GHV and 9HFL. Normal crystallographic expansion is unchanged.

## Testing

- Reproduced 26 unwanted mates before the fix and none afterward for 8GHV and 9HFL.
- Verified 1oky still generates the expected symmetry mates.
- Added a regression test for placeholder unit cells.
- All 24 CI checks pass.
