### PR TITLE
fix(editing): drive protonate fallback with pKa-based formal charges

### DIFF
--- a/layer2/AtomInfo.cpp
+++ b/layer2/AtomInfo.cpp
@@ -2281,7 +2281,7 @@ int AtomInfoGetExpectedValence(PyMOLGlobals * G, const AtomInfoType * I)
       result = -1;
       break;
     case cAN_S:
-      result = -2;
+      result = -1;
       break;
     case cAN_P:
       result = -3;

--- a/layer2/AtomInfo.cpp
+++ b/layer2/AtomInfo.cpp
@@ -2281,6 +2281,8 @@ int AtomInfoGetExpectedValence(PyMOLGlobals * G, const AtomInfoType * I)
       result = -1;
       break;
     case cAN_S:
+      /* thiolate: a single bond already satisfies the anion (unlike
+         neutral sulfur, which expects at least two) */
       result = -1;
       break;
     case cAN_P:

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1301,6 +1301,39 @@ SEE ALSO
         pKa, charge_below, charge_above = value
         return charge_below if pH < pKa else charge_above
 
+    def _make_titratable_selection():
+        """Selection matching exactly the atoms _get_formal_charge can change.
+
+        Writing formal_charge clears an atom's chemFlag, which discards any
+        hand-corrected geometry (see "set_geometry"), so the fallback must
+        only touch atoms it actually has a pKa for.
+        """
+        names_by_resn = {}
+        for resn, name in _TITRATABLE_PKA_FORMAL_CHARGE:
+            names_by_resn.setdefault(resn, set()).add(name)
+
+        # expand the canonical tautomers back into every spelling that
+        # _get_formal_charge normalizes onto them
+        by_input_resn = {}
+        for alias, tautomer in _HIS_TAUTOMER.items():
+            by_input_resn.setdefault(alias, set()).update(
+                names_by_resn.get(tautomer, ()))
+        for resn, names in names_by_resn.items():
+            if resn not in _HIS_TAUTOMER.values():
+                by_input_resn.setdefault(resn, set()).update(names)
+
+        # collapse residues which share an atom name set into one term
+        resns_by_names = {}
+        for resn, names in by_input_resn.items():
+            resns_by_names.setdefault(
+                '+'.join(sorted(names)), set()).add(resn)
+
+        return ' or '.join(
+            f"(resn {'+'.join(sorted(resns))} and name {names})"
+            for names, resns in sorted(resns_by_names.items()))
+
+    _TITRATABLE_SELECTION = _make_titratable_selection()
+
     def _force_add_h(obj_name, atom_sele, deficit, state, _self):
         """Temporarily bump valence to force h_add on a saturated atom."""
         _self.alter(atom_sele, f"valence = valence + {deficit}")
@@ -1329,7 +1362,7 @@ SEE ALSO
 
         _self.remove(f"hydro and (bymol ({obj_sele}))")
         _self.alter(
-            obj_sele,
+            f"({obj_sele}) and ({_TITRATABLE_SELECTION})",
             "formal_charge = _get_formal_charge(resn, name, formal_charge)",
             space={
                 "_get_formal_charge": partial(_get_formal_charge, pH=pH),
@@ -1461,7 +1494,9 @@ DESCRIPTION
     given pH.
 
     Heavy atoms and their visual settings (colors, representations) are
-    preserved. Only hydrogens are modified.
+    preserved. Hydrogens are rebuilt, and the fallback additionally
+    rewrites "formal_charge" on the titratable side chain atoms listed
+    under NOTES.
 
 USAGE
 
@@ -1488,6 +1523,14 @@ NOTES
     Without pdb2pqr, textbook pKa values are used:
       Asp 3.65, Glu 4.25, His 6.00, Cys 8.18,
       Tyr 10.07, Lys 10.53, Arg 12.48
+
+    The fallback drives h_add by assigning "formal_charge" on the
+    titratable atoms of those residues (Asp OD1/OD2, Glu OE1/OE2, His
+    ND1/NE2, Cys SG, Tyr OH, Lys NZ, Arg NE/NH1/NH2). Any charge the
+    input file supplied for one of those atoms is overwritten, and the
+    new value persists on the object, so it is written out by formats
+    which store formal charges (mol2, mmCIF, mae). All other atoms are
+    left alone.
 
     Cysteines whose SG is bonded to anything other than its own CB
     (disulfide bridge, metal, alkylation) have no ionizable hydrogen and

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1255,27 +1255,35 @@ SEE ALSO
         return r
 
 
-    # Textbook pKa values for standard titratable residues.
-    # Used as fallback when pdb2pqr is not available.
-    # At a given pH, if pH > pKa the group is deprotonated (fewer H).
-    # Format: (resn, atom_names) → pKa
-    # H count when protonated vs deprotonated is specified per entry.
-    _TITRATABLE_PKA = {
-        # Carboxylates: protonated = 1H on OD2/OE2, deprotonated = 0H
-        ('ASP', ('OD1', 'OD2')): 3.65,
-        ('GLU', ('OE1', 'OE2')): 4.25,
-        # Histidine: protonated = H on both ND1+NE2, deprotonated = H on NE2 only
-        # Note: assumes HIE tautomer. pdb2pqr path handles HID/HIE/HIP properly.
-        ('HIS', ('ND1',)):       6.00,
-        # Cysteine: protonated = 1H on SG, deprotonated = 0H
-        ('CYS', ('SG',)):        8.18,
-        # Tyrosine: protonated = 1H on OH, deprotonated = 0H
-        ('TYR', ('OH',)):       10.07,
-        # Lysine: protonated = 3H on NZ, deprotonated = 2H
-        ('LYS', ('NZ',)):       10.53,
-        # Arginine: practically always protonated
-        ('ARG', ('NH1', 'NH2')): 12.48,
+    # Textbook pKa values and formal charges for standard titratable
+    # residues. Used as fallback when pdb2pqr is not available.
+    # Format: (resn, name) -> (pKa, charge below pKa, charge at/above pKa)
+    _TITRATABLE_PKA_FORMAL_CHARGE = {
+        ('ARG', 'NE'):  (12.48,  0,  0),
+        ('ARG', 'NH1'): (12.48,  1,  0),
+        ('ARG', 'NH2'): (12.48,  0,  0),
+        ('LYS', 'NZ'):  (10.53,  1,  0),
+        ('TYR', 'OH'):  (10.07,  0, -1),
+        ('CYS', 'SG'):  (8.18,   0, -1),
+        ('HIE', 'ND1'): (6.00,   1,  0),
+        ('HIP', 'ND1'): (6.00,   1,  0),
+        ('HIS', 'ND1'): (6.00,   1,  0),
+        ('HIE', 'NE2'): (6.00,   0,  0),
+        ('HIP', 'NE2'): (6.00,   0,  0),
+        ('HIS', 'NE2'): (6.00,   0,  0),
+        ('GLU', 'OE1'): (4.25,   0,  0),
+        ('GLU', 'OE2'): (4.25,   0, -1),
+        ('ASP', 'OD1'): (3.65,   0,  0),
+        ('ASP', 'OD2'): (3.65,   0, -1),
     }
+
+    def _get_formal_charge(resn, name, pH, fallback):
+        value = _TITRATABLE_PKA_FORMAL_CHARGE.get((resn, name))
+        if value is None:
+            return fallback
+
+        pKa, charge_below, charge_above = value
+        return charge_below if pH < pKa else charge_above
 
     def _force_add_h(obj_name, atom_sele, deficit, state, _self):
         """Temporarily bump valence to force h_add on a saturated atom."""
@@ -1296,49 +1304,21 @@ SEE ALSO
     def _protonate_fallback(selection, obj_name, pH, state, quiet, _self):
         """pH-aware protonation using textbook pKa values.
 
-        Adds all H via h_add, then adjusts titratable groups based on
-        whether pH > pKa (deprotonated) or pH < pKa (protonated).
+        Sets formal charges for titratable groups, then lets h_add determine
+        bond valences and hydrogen counts.
         """
-        from pymol import stored
-
         obj_sele = f"({selection}) and {obj_name}"
 
-        # Strip existing H and add all H geometrically
         _self.remove(f"hydro and (bymol ({obj_sele}))")
+        _self.alter(
+            obj_sele,
+            f"formal_charge = _get_formal_charge("
+            f"resn, name, {pH!r}, formal_charge)",
+            space={
+                "_get_formal_charge": _get_formal_charge,
+            },
+            quiet=quiet)
         _self.h_add(obj_sele, state=state)
-
-        # Adjust titratable groups
-        for (resn, atom_names), pKa in _TITRATABLE_PKA.items():
-            deprotonated = pH > pKa
-
-            if not deprotonated:
-                # Group should be protonated. h_add may not have added
-                # H if the valence is already satisfied (e.g. carboxylate
-                # double bond, His imidazole). Bump valence to force it.
-                for atom_name in atom_names:
-                    sele = f"{obj_name} and resn {resn} and name {atom_name}"
-                    stored._prot_ids = []
-                    _self.iterate(sele, "stored._prot_ids.append(ID)")
-                    for aid in stored._prot_ids:
-                        atom_sele = f"{obj_name} and ID {aid}"
-                        h_count = _self.count_atoms(
-                            f"hydro and neighbor ({atom_sele})")
-                        if h_count == 0:
-                            _force_add_h(obj_name, atom_sele, 1, state,
-                                         _self)
-                continue
-
-            # pH > pKa: group should be deprotonated — remove H
-            for atom_name in atom_names:
-                h_sele = (f"hydro and neighbor "
-                          f"({obj_name} and resn {resn} and name {atom_name})")
-                h_count = _self.count_atoms(h_sele)
-                if h_count > 0:
-                    if resn == 'LYS' and atom_name == 'NZ':
-                        # Deprotonated Lys: NH2 (2H), not NH3+ (3H)
-                        _remove_excess_h(obj_name, h_sele, 1, _self)
-                    else:
-                        _self.remove(h_sele)
 
         if not quiet:
             total_h = _self.count_atoms(f"hydro and (bymol ({obj_sele}))")

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1388,9 +1388,9 @@ SEE ALSO
         bridged = []
         if sg_indices:
             # every heavy neighbour of every SG in one pass; the model's own
-            # bond list keeps atom positions and indices consistent. Bonds
-            # do not vary between states, so a single state is enough (and
-            # required: a multi-state model repeats its atoms per state).
+            # bond list keeps atom positions and indices consistent. A single
+            # state is required here: a multi-state model repeats its atoms
+            # per state, which breaks that position/index correspondence.
             model = _self.get_model(
                 f"({obj_name} and not hydro) and "
                 f"(({sg_sele}) or neighbor ({sg_sele}))", CURRENT_STATE)
@@ -1401,6 +1401,19 @@ SEE ALSO
                     if positions[pos] in degree:
                         degree[positions[pos]] += 1
             bridged = [i for i, d in degree.items() if d > 1]
+
+            # a discrete object keeps each atom in a single coordset, so an
+            # SG outside the exported state is missing from the model above.
+            # Bonds are per object, not per state, so count its neighbours
+            # through the selector instead of assuming it is a free thiol.
+            exported = set(positions)
+            for index in sg_indices:
+                if index in exported:
+                    continue
+                if _self.count_atoms(
+                        f"({obj_name} and not hydro) and neighbor "
+                        f"({obj_name} and index {index})") > 1:
+                    bridged.append(index)
         if bridged:
             _self.alter(
                 f"{obj_name} and index {'+'.join(map(str, bridged))}",
@@ -1572,17 +1585,18 @@ NOTES
     GLUM, LYSP and the histidine names below). Any charge the input file
     supplied for one of those atoms is overwritten, and the new value
     persists on the object, so it is written out by formats which store
-    formal charges (PDB, mol2, mmCIF, mae). All other atoms are left
-    alone.
+    formal charges (PDB, mmCIF, mae). All other atoms are left alone.
 
-    Reloading a saved PDB does not always preserve those charges: the
-    PDB reader re-derives a charge from the residue name for ARG/ARGP
-    NH1, LYS/LYSP NZ, ASP/ASPM OD2 and GLU/GLUM OE2 and overrides
-    whatever the file records. A residue titrated outside its pKa window
-    (a neutral lysine above pH 10.53, a protonated aspartate below pH
-    3.65) therefore comes back charged after a PDB round trip while its
-    hydrogens stay as protonate built them. Use a format without that
-    re-derivation (mol2, mmCIF, mae) to keep the two consistent.
+    Reloading a saved file does not always preserve those charges. Any
+    format PyMOL has to bond by distance (PDB and mmCIF both, since the
+    mmCIF exporter writes no bond records) re-derives a charge from the
+    residue name for ARG/ARGP NH1, LYS/LYSP NZ, ASP/ASPM OD2 and
+    GLU/GLUM OE2, overriding whatever the file records; mol2 does not
+    store formal charges at all and the reader re-derives them from the
+    SYBYL atom types. A residue titrated outside its pKa window (a
+    neutral lysine above pH 10.53, a protonated aspartate below pH 3.65)
+    therefore comes back charged after such a round trip while its
+    hydrogens stay as protonate built them.
 
     A cysteine SG with a second heavy neighbour (disulfide bridge,
     metal, alkylation) has no ionizable hydrogen and is left neutral.

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1550,7 +1550,8 @@ DESCRIPTION
     preserved. Hydrogens inside the selection, and those bonded to it,
     are rebuilt; hydrogens on unselected heavy atoms are left alone. The
     fallback additionally rewrites "formal_charge" on the titratable side
-    chain atoms listed under NOTES.
+    chain atoms listed under NOTES, and renames a histidine which the
+    residue name would otherwise keep protonated (see NOTES).
 
 USAGE
 
@@ -1585,7 +1586,9 @@ NOTES
     GLUM, LYSP and the histidine names below). Any charge the input file
     supplied for one of those atoms is overwritten, and the new value
     persists on the object, so it is written out by formats which store
-    formal charges (PDB, mmCIF, mae). All other atoms are left alone.
+    formal charges (PDB, mmCIF, mae). Writing a charge also discards any
+    manual chemistry correction ("set_geometry") on that atom. All other
+    atoms are left alone.
 
     Reloading a saved file does not always preserve those charges. Any
     format PyMOL has to bond by distance (PDB and mmCIF both, since the
@@ -1601,11 +1604,19 @@ NOTES
     A cysteine SG with a second heavy neighbour (disulfide bridge,
     metal, alkylation) has no ionizable hydrogen and is left neutral.
     Histidine titrates on whichever ring nitrogen is free in the
-    tautomer implied by the residue name (HID/HISA/HISD have the free
-    nitrogen at NE2, all other spellings at ND1). The explicitly
-    protonated spellings HIP/HISH/HISP are read back as imidazolium no
-    matter what charge a file records, so a residue which loses its
-    proton above pH 6 is renamed to neutral HIS.
+    tautomer implied by the residue name: HID, HISA and HISD have the
+    free nitrogen at NE2, while HIS, HISB, HISE, HIE, HIP, HISH and
+    HISP have it at ND1. The explicitly protonated spellings
+    HIP/HISH/HISP are read back as imidazolium no matter what charge a
+    file records, so a residue which loses its proton above pH 6 is
+    renamed to neutral HIS.
+
+    Everything the table does not cover only gets the hydrogens h_add
+    fills its open valences with. In particular the fallback does not
+    titrate peptide termini, ligands or nucleic acids: they keep the
+    charge the input carries at every pH. The pdb2pqr path knows no such
+    restriction and reproduces whatever pdb2pqr builds, termini
+    included.
 
     At biological pH (7.4):
       - Asp/Glu carboxylates are deprotonated (COO-)

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1382,12 +1382,25 @@ SEE ALSO
         # Only a free thiol titrates. A cysteine sulfur carrying a second
         # heavy neighbour (disulfide bridge, metal, alkylation) has no
         # ionizable H and stays neutral.
+        sg_sele = f"({obj_sele}) and resn CYS and name SG"
         sg_indices = []
-        _self.iterate(f"({obj_sele}) and resn CYS and name SG",
-                      "sg.append(index)", space={"sg": sg_indices})
-        bridged = [i for i in sg_indices if _self.count_atoms(
-            f"({obj_name} and not hydro) and neighbor "
-            f"({obj_name} and index {i})") > 1]
+        _self.iterate(sg_sele, "sg.append(index)", space={"sg": sg_indices})
+        bridged = []
+        if sg_indices:
+            # every heavy neighbour of every SG in one pass; the model's own
+            # bond list keeps atom positions and indices consistent. Bonds
+            # do not vary between states, so a single state is enough (and
+            # required: a multi-state model repeats its atoms per state).
+            model = _self.get_model(
+                f"({obj_name} and not hydro) and "
+                f"(({sg_sele}) or neighbor ({sg_sele}))", CURRENT_STATE)
+            degree = dict.fromkeys(sg_indices, 0)
+            positions = [a.index for a in model.atom]
+            for bond in model.bond:
+                for pos in bond.index:
+                    if positions[pos] in degree:
+                        degree[positions[pos]] += 1
+            bridged = [i for i, d in degree.items() if d > 1]
         if bridged:
             _self.alter(
                 f"{obj_name} and index {'+'.join(map(str, bridged))}",
@@ -1486,12 +1499,12 @@ SEE ALSO
                     f'resi {resi} and name {name})')
                 if _self.count_atoms(heavy_sele) == 0:
                     continue
-                h_sele = f"hydro and neighbor ({heavy_sele})"
-                current_h = _self.count_atoms(h_sele)
+                atom_h_sele = f"hydro and neighbor ({heavy_sele})"
+                current_h = _self.count_atoms(atom_h_sele)
 
                 if current_h > target_h:
                     excess = current_h - target_h
-                    _remove_excess_h(obj_name, h_sele, excess, _self)
+                    _remove_excess_h(obj_name, atom_h_sele, excess, _self)
                 elif current_h < target_h:
                     deficit = target_h - current_h
                     _force_add_h(obj_name, heavy_sele, deficit, state,
@@ -1561,6 +1574,15 @@ NOTES
     persists on the object, so it is written out by formats which store
     formal charges (PDB, mol2, mmCIF, mae). All other atoms are left
     alone.
+
+    Reloading a saved PDB does not always preserve those charges: the
+    PDB reader re-derives a charge from the residue name for ARG/ARGP
+    NH1, LYS/LYSP NZ, ASP/ASPM OD2 and GLU/GLUM OE2 and overrides
+    whatever the file records. A residue titrated outside its pKa window
+    (a neutral lysine above pH 10.53, a protonated aspartate below pH
+    3.65) therefore comes back charged after a PDB round trip while its
+    hydrogens stay as protonate built them. Use a format without that
+    re-derivation (mol2, mmCIF, mae) to keep the two consistent.
 
     A cysteine SG with a second heavy neighbour (disulfide bridge,
     metal, alkylation) has no ionizable hydrogen and is left neutral.

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1272,6 +1272,18 @@ SEE ALSO
         'HISD': 'HID',
     }
 
+    # Every residue spelling the PDB reader assigns formal charges for,
+    # mapped onto the name the pKa table is keyed on. Besides the histidine
+    # tautomers, the reader accepts the Gromacs/Quanta spellings of the
+    # charged forms (see assign_pdb_known_residue).
+    _RESN_ALIAS = dict(_HIS_TAUTOMER,
+                       ARGP='ARG', ASPM='ASP', GLUM='GLU', LYSP='LYS')
+
+    # Histidine spellings for which the PDB reader unconditionally restores
+    # ND1 = +1, so a deprotonated one has to be renamed to keep its charge
+    # across a PDB round trip.
+    _HIS_CATIONIC = ('HIP', 'HISH', 'HISP')
+
     # Textbook pKa values and formal charges for standard titratable
     # residues. Used as fallback when pdb2pqr is not available.
     # Format: (resn, name) -> (pKa, charge below pKa, charge at/above pKa)
@@ -1294,7 +1306,7 @@ SEE ALSO
 
     def _get_formal_charge(resn, name, fallback, pH):
         resn = resn.upper()
-        key = (_HIS_TAUTOMER.get(resn, resn), name.upper())
+        key = (_RESN_ALIAS.get(resn, resn), name.upper())
         value = _TITRATABLE_PKA_FORMAL_CHARGE.get(key)
         if value is None:
             return fallback
@@ -1313,10 +1325,10 @@ SEE ALSO
         for resn, name in _TITRATABLE_PKA_FORMAL_CHARGE:
             names_by_resn.setdefault(resn, []).append(name)
 
-        # one term per spelling _get_formal_charge accepts: histidines
-        # normalize onto a tautomer, every other residue onto itself
+        # one term per spelling _get_formal_charge accepts: aliases
+        # normalize onto their canonical name, every other residue onto itself
         canonical = {resn: resn for resn in names_by_resn}
-        canonical.update(_HIS_TAUTOMER)
+        canonical.update(_RESN_ALIAS)
 
         return ' or '.join(
             f"(resn {resn} and name {'+'.join(names_by_resn[tautomer])})"
@@ -1324,6 +1336,12 @@ SEE ALSO
             if tautomer in names_by_resn)
 
     _TITRATABLE_SELECTION = _make_titratable_selection()
+
+    def _owned_hydrogens(obj_sele):
+        """Hydrogens a protonation run owns: those inside the selection plus
+        those hanging off it. Hydrogens on unselected heavy atoms belong to
+        somebody else and must survive a partial selection."""
+        return f"hydro and (({obj_sele}) or neighbor ({obj_sele}))"
 
     def _force_add_h(obj_name, atom_sele, deficit, state, _self):
         """Temporarily bump valence to force h_add on a saturated atom."""
@@ -1350,8 +1368,9 @@ SEE ALSO
         from functools import partial
 
         obj_sele = f"({selection}) and {obj_name}"
+        h_sele = _owned_hydrogens(obj_sele)
 
-        _self.remove(f"hydro and (bymol ({obj_sele}))")
+        _self.remove(h_sele)
         _self.alter(
             f"({obj_sele}) and ({_TITRATABLE_SELECTION})",
             "formal_charge = _get_formal_charge(resn, name, formal_charge)",
@@ -1359,18 +1378,35 @@ SEE ALSO
                 "_get_formal_charge": partial(_get_formal_charge, pH=pH),
             },
             quiet=quiet)
-        # Only a free thiol titrates. A cysteine sulfur which is bonded to
-        # anything but its own CB (disulfide bridge, metal, alkylation) has
-        # no ionizable H and stays neutral.
-        _self.alter(
-            f"({obj_sele}) and resn CYS and name SG and "
-            f"bound_to ({obj_name} and not name CB)",
-            "formal_charge = 0",
-            quiet=quiet)
+
+        # Only a free thiol titrates. A cysteine sulfur carrying a second
+        # heavy neighbour (disulfide bridge, metal, alkylation) has no
+        # ionizable H and stays neutral.
+        sg_indices = []
+        _self.iterate(f"({obj_sele}) and resn CYS and name SG",
+                      "sg.append(index)", space={"sg": sg_indices})
+        bridged = [i for i in sg_indices if _self.count_atoms(
+            f"({obj_name} and not hydro) and neighbor "
+            f"({obj_name} and index {i})") > 1]
+        if bridged:
+            _self.alter(
+                f"{obj_name} and index {'+'.join(map(str, bridged))}",
+                "formal_charge = 0",
+                quiet=quiet)
+
+        # The PDB reader restores ND1 = +1 for these spellings no matter what
+        # charge the file carries, so a demoted one has to give up its name.
+        if _get_formal_charge('HIP', 'ND1', 0, pH) == 0:
+            _self.alter(
+                f"byres (({obj_sele}) and "
+                f"resn {'+'.join(_HIS_CATIONIC)} and name ND1)",
+                "resn = 'HIS'",
+                quiet=quiet)
+
         _self.h_add(obj_sele, state=state)
 
         if not quiet:
-            total_h = _self.count_atoms(f"hydro and (bymol ({obj_sele}))")
+            total_h = _self.count_atoms(h_sele)
             print(f" protonate: added {total_h} hydrogens at pH {pH:.1f}"
                   " (using textbook pKa values)")
 
@@ -1384,6 +1420,7 @@ SEE ALSO
         from pymol import stored
 
         obj_sele = f"({selection}) and {obj_name}"
+        h_sele = _owned_hydrogens(obj_sele)
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1438,14 +1475,14 @@ SEE ALSO
                         (chain, resi, resn, name)] = h_count
 
             # Strip existing H and add all H geometrically
-            _self.remove(f"hydro and (bymol ({obj_sele}))")
+            _self.remove(h_sele)
             _self.h_add(obj_sele, state=state)
 
             # Compare and adjust H counts per heavy atom
             for key, target_h in stored._prot_hcount.items():
                 chain, resi, resn, name = key
                 heavy_sele = (
-                    f'({obj_name} and chain "{chain}" and '
+                    f'(({obj_sele}) and chain "{chain}" and '
                     f'resi {resi} and name {name})')
                 if _self.count_atoms(heavy_sele) == 0:
                     continue
@@ -1463,8 +1500,7 @@ SEE ALSO
             _self.delete(tmp_obj)
 
             if not quiet:
-                total_h = _self.count_atoms(
-                    f"hydro and (bymol ({obj_sele}))")
+                total_h = _self.count_atoms(h_sele)
                 print(f" protonate: added {total_h} hydrogens at pH {pH:.1f}")
 
         finally:
@@ -1485,9 +1521,10 @@ DESCRIPTION
     given pH.
 
     Heavy atoms and their visual settings (colors, representations) are
-    preserved. Hydrogens are rebuilt, and the fallback additionally
-    rewrites "formal_charge" on the titratable side chain atoms listed
-    under NOTES.
+    preserved. Hydrogens inside the selection, and those bonded to it,
+    are rebuilt; hydrogens on unselected heavy atoms are left alone. The
+    fallback additionally rewrites "formal_charge" on the titratable side
+    chain atoms listed under NOTES.
 
 USAGE
 
@@ -1517,20 +1554,22 @@ NOTES
 
     The fallback drives h_add by assigning "formal_charge" on the
     titratable atoms of those residues (Asp OD1/OD2, Glu OE1/OE2, His
-    ND1/NE2, Cys SG, Tyr OH, Lys NZ, Arg NE/NH1/NH2). Any charge the
-    input file supplied for one of those atoms is overwritten, and the
-    new value persists on the object, so it is written out by formats
-    which store formal charges (mol2, mmCIF, mae). All other atoms are
-    left alone.
+    ND1/NE2, Cys SG, Tyr OH, Lys NZ, Arg NE/NH1/NH2), including the
+    Gromacs/Quanta spellings the PDB reader recognizes (ARGP, ASPM,
+    GLUM, LYSP and the histidine names below). Any charge the input file
+    supplied for one of those atoms is overwritten, and the new value
+    persists on the object, so it is written out by formats which store
+    formal charges (PDB, mol2, mmCIF, mae). All other atoms are left
+    alone.
 
-    Cysteines whose SG is bonded to anything other than its own CB
-    (disulfide bridge, metal, alkylation) have no ionizable hydrogen and
-    are left neutral. Histidine titrates on whichever ring nitrogen is
-    free in the tautomer implied by the residue name (HID/HISA/HISD have
-    the free nitrogen at NE2, all other spellings at ND1). The
-    explicitly protonated spellings HIP/HISH/HISP are treated as
-    ordinary histidine, so above pH 6 they are deprotonated but keep
-    their name, leaving the residue name at odds with the hydrogen count.
+    A cysteine SG with a second heavy neighbour (disulfide bridge,
+    metal, alkylation) has no ionizable hydrogen and is left neutral.
+    Histidine titrates on whichever ring nitrogen is free in the
+    tautomer implied by the residue name (HID/HISA/HISD have the free
+    nitrogen at NE2, all other spellings at ND1). The explicitly
+    protonated spellings HIP/HISH/HISP are read back as imidazolium no
+    matter what charge a file records, so a residue which loses its
+    proton above pH 6 is renamed to neutral HIS.
 
     At biological pH (7.4):
       - Asp/Glu carboxylates are deprotonated (COO-)

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1255,6 +1255,23 @@ SEE ALSO
         return r
 
 
+    # Histidine spellings understood by the PDB reader, mapped to the
+    # imidazole tautomer they encode. HIE-like names put the CE1 double
+    # bond on ND1 (so NE2 carries the neutral H), HID-like names put it
+    # on NE2 (so ND1 carries the neutral H).
+    _HIS_TAUTOMER = {
+        'HIS':  'HIE',
+        'HISB': 'HIE',
+        'HISE': 'HIE',
+        'HIE':  'HIE',
+        'HIP':  'HIE',
+        'HISH': 'HIE',
+        'HISP': 'HIE',
+        'HID':  'HID',
+        'HISA': 'HID',
+        'HISD': 'HID',
+    }
+
     # Textbook pKa values and formal charges for standard titratable
     # residues. Used as fallback when pdb2pqr is not available.
     # Format: (resn, name) -> (pKa, charge below pKa, charge at/above pKa)
@@ -1266,19 +1283,18 @@ SEE ALSO
         ('TYR', 'OH'):  (10.07,  0, -1),
         ('CYS', 'SG'):  (8.18,   0, -1),
         ('HIE', 'ND1'): (6.00,   1,  0),
-        ('HIP', 'ND1'): (6.00,   1,  0),
-        ('HIS', 'ND1'): (6.00,   1,  0),
         ('HIE', 'NE2'): (6.00,   0,  0),
-        ('HIP', 'NE2'): (6.00,   0,  0),
-        ('HIS', 'NE2'): (6.00,   0,  0),
+        ('HID', 'ND1'): (6.00,   0,  0),
+        ('HID', 'NE2'): (6.00,   1,  0),
         ('GLU', 'OE1'): (4.25,   0,  0),
         ('GLU', 'OE2'): (4.25,   0, -1),
         ('ASP', 'OD1'): (3.65,   0,  0),
         ('ASP', 'OD2'): (3.65,   0, -1),
     }
 
-    def _get_formal_charge(resn, name, pH, fallback):
-        value = _TITRATABLE_PKA_FORMAL_CHARGE.get((resn, name))
+    def _get_formal_charge(resn, name, fallback, pH):
+        key = (_HIS_TAUTOMER.get(resn, resn), name)
+        value = _TITRATABLE_PKA_FORMAL_CHARGE.get(key)
         if value is None:
             return fallback
 
@@ -1307,16 +1323,25 @@ SEE ALSO
         Sets formal charges for titratable groups, then lets h_add determine
         bond valences and hydrogen counts.
         """
+        from functools import partial
+
         obj_sele = f"({selection}) and {obj_name}"
 
         _self.remove(f"hydro and (bymol ({obj_sele}))")
         _self.alter(
             obj_sele,
-            f"formal_charge = _get_formal_charge("
-            f"resn, name, {pH!r}, formal_charge)",
+            "formal_charge = _get_formal_charge(resn, name, formal_charge)",
             space={
-                "_get_formal_charge": _get_formal_charge,
+                "_get_formal_charge": partial(_get_formal_charge, pH=pH),
             },
+            quiet=quiet)
+        # Only a free thiol titrates. A cysteine sulfur which is bonded to
+        # anything but its own CB (disulfide bridge, metal, alkylation) has
+        # no ionizable H and stays neutral.
+        _self.alter(
+            f"({obj_sele}) and resn CYS and name SG and "
+            f"bound_to ({obj_name} and not name CB)",
+            "formal_charge = 0",
             quiet=quiet)
         _self.h_add(obj_sele, state=state)
 
@@ -1463,6 +1488,12 @@ NOTES
     Without pdb2pqr, textbook pKa values are used:
       Asp 3.65, Glu 4.25, His 6.00, Cys 8.18,
       Tyr 10.07, Lys 10.53, Arg 12.48
+
+    Cysteines whose SG is bonded to anything other than its own CB
+    (disulfide bridge, metal, alkylation) have no ionizable hydrogen and
+    are left neutral. Histidine titrates on whichever ring nitrogen is
+    free in the tautomer implied by the residue name (HID/HISA/HISD have
+    the free nitrogen at NE2, all other spellings at ND1).
 
     At biological pH (7.4):
       - Asp/Glu carboxylates are deprotonated (COO-)

--- a/modules/pymol/editing.py
+++ b/modules/pymol/editing.py
@@ -1293,7 +1293,8 @@ SEE ALSO
     }
 
     def _get_formal_charge(resn, name, fallback, pH):
-        key = (_HIS_TAUTOMER.get(resn, resn), name)
+        resn = resn.upper()
+        key = (_HIS_TAUTOMER.get(resn, resn), name.upper())
         value = _TITRATABLE_PKA_FORMAL_CHARGE.get(key)
         if value is None:
             return fallback
@@ -1310,27 +1311,17 @@ SEE ALSO
         """
         names_by_resn = {}
         for resn, name in _TITRATABLE_PKA_FORMAL_CHARGE:
-            names_by_resn.setdefault(resn, set()).add(name)
+            names_by_resn.setdefault(resn, []).append(name)
 
-        # expand the canonical tautomers back into every spelling that
-        # _get_formal_charge normalizes onto them
-        by_input_resn = {}
-        for alias, tautomer in _HIS_TAUTOMER.items():
-            by_input_resn.setdefault(alias, set()).update(
-                names_by_resn.get(tautomer, ()))
-        for resn, names in names_by_resn.items():
-            if resn not in _HIS_TAUTOMER.values():
-                by_input_resn.setdefault(resn, set()).update(names)
-
-        # collapse residues which share an atom name set into one term
-        resns_by_names = {}
-        for resn, names in by_input_resn.items():
-            resns_by_names.setdefault(
-                '+'.join(sorted(names)), set()).add(resn)
+        # one term per spelling _get_formal_charge accepts: histidines
+        # normalize onto a tautomer, every other residue onto itself
+        canonical = {resn: resn for resn in names_by_resn}
+        canonical.update(_HIS_TAUTOMER)
 
         return ' or '.join(
-            f"(resn {'+'.join(sorted(resns))} and name {names})"
-            for names, resns in sorted(resns_by_names.items()))
+            f"(resn {resn} and name {'+'.join(names_by_resn[tautomer])})"
+            for resn, tautomer in sorted(canonical.items())
+            if tautomer in names_by_resn)
 
     _TITRATABLE_SELECTION = _make_titratable_selection()
 
@@ -1536,7 +1527,10 @@ NOTES
     (disulfide bridge, metal, alkylation) have no ionizable hydrogen and
     are left neutral. Histidine titrates on whichever ring nitrogen is
     free in the tautomer implied by the residue name (HID/HISA/HISD have
-    the free nitrogen at NE2, all other spellings at ND1).
+    the free nitrogen at NE2, all other spellings at ND1). The
+    explicitly protonated spellings HIP/HISH/HISP are treated as
+    ordinary histidine, so above pH 6 they are deprotonated but keep
+    their name, leaving the residue name at odds with the hydrogen count.
 
     At biological pH (7.4):
       - Asp/Glu carboxylates are deprotonated (COO-)

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -167,6 +167,127 @@ def test_protonate_fallback_pH_transitions():
         assert cmd.count_atoms("m1 and hydro") == hydrogen_count
 
 
+def _formal_charges(selection):
+    charges = []
+    cmd.iterate(selection, "charges.append(formal_charge)",
+                space={"charges": charges})
+    return charges
+
+
+def test_protonate_fallback_free_cysteine():
+    """A free thiol loses its H and turns into a thiolate above pKa 8.18."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("ACA", "m1")
+
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms("m1 and hydro and neighbor (name SG)") == 1
+    assert _formal_charges("m1 and name SG") == [0]
+
+    _protonate_fallback("m1", "m1", 9.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms("m1 and hydro and neighbor (name SG)") == 0
+    assert _formal_charges("m1 and name SG") == [-1]
+
+    # and back down again
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms("m1 and hydro and neighbor (name SG)") == 1
+    assert _formal_charges("m1 and name SG") == [0]
+
+
+def test_protonate_fallback_disulfide_stays_neutral():
+    """A bridged cysteine has no ionizable H, so it must not pick up -1."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("CGC", "m1")
+    cmd.bond("m1 and resi 1 and name SG", "m1 and resi 3 and name SG")
+
+    _protonate_fallback("m1", "m1", 13.0, 0, 1, _self=cmd)
+
+    assert cmd.count_atoms("m1 and hydro and neighbor (name SG)") == 0
+    assert _formal_charges("m1 and name SG") == [0, 0]
+
+
+def test_protonate_fallback_tyrosine_and_arginine():
+    """Tyr and Arg bracket the pH range covered by the fallback table."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("YR", "m1")
+
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms("m1 and hydro and neighbor (name OH)") == 1
+    assert _formal_charges("m1 and name OH") == [0]
+    assert cmd.count_atoms(
+        "m1 and hydro and neighbor (name NE+NH1+NH2)") == 5
+    assert _formal_charges("m1 and name NH1") == [1]
+
+    _protonate_fallback("m1", "m1", 13.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms("m1 and hydro and neighbor (name OH)") == 0
+    assert _formal_charges("m1 and name OH") == [-1]
+    assert cmd.count_atoms(
+        "m1 and hydro and neighbor (name NE+NH1+NH2)") == 4
+    assert _formal_charges("m1 and name NH1") == [0]
+
+
+def _build_his_tautomer(resn, obj_name):
+    """Build a histidine and round-trip it through PDB under `resn` so that
+    the reader assigns the imidazole bond orders that name implies."""
+    cmd.fab("H", "_his_tmp")
+    cmd.alter("_his_tmp", f"resn = {resn!r}")
+    pdbstr = cmd.get_pdbstr("_his_tmp and not hydro")
+    cmd.delete("_his_tmp")
+    cmd.read_pdbstr(pdbstr, obj_name)
+
+
+@pytest.mark.parametrize("resn,neutral_h_on", [
+    ("HIS", "NE2"),
+    ("HID", "ND1"),
+    ("HIE", "NE2"),
+])
+def test_protonate_fallback_his_tautomers(resn, neutral_h_on):
+    """Both imidazole tautomers must titrate on their own free nitrogen."""
+    from pymol.editing import _protonate_fallback
+
+    other = "ND1" if neutral_h_on == "NE2" else "NE2"
+    _build_his_tautomer(resn, "m1")
+
+    # above pKa 6.0: neutral, single ring H on the tautomer's nitrogen
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms(
+        f"m1 and hydro and neighbor (name {neutral_h_on})") == 1
+    assert cmd.count_atoms(f"m1 and hydro and neighbor (name {other})") == 0
+    assert _formal_charges("m1 and name ND1+NE2") == [0, 0]
+
+    # below pKa 6.0: imidazolium, one H on each ring nitrogen
+    _protonate_fallback("m1", "m1", 5.0, 0, 1, _self=cmd)
+    assert cmd.count_atoms(
+        f"m1 and hydro and neighbor (name {neutral_h_on})") == 1
+    assert cmd.count_atoms(f"m1 and hydro and neighbor (name {other})") == 1
+    assert sum(_formal_charges("m1 and name ND1+NE2")) == 1
+
+
+@pytest.mark.parametrize("resn", ["HIS", "HISB", "HISE", "HIE", "HIP",
+                                  "HISH", "HISP"])
+def test_protonate_his_epsilon_aliases(resn):
+    """Names the PDB reader double bonds CE1=ND1 titrate on ND1."""
+    from pymol.editing import _get_formal_charge
+
+    assert _get_formal_charge(resn, 'ND1', 0, 5.0) == 1
+    assert _get_formal_charge(resn, 'NE2', 0, 5.0) == 0
+    assert _get_formal_charge(resn, 'ND1', 0, 7.0) == 0
+    assert _get_formal_charge(resn, 'NE2', 0, 7.0) == 0
+
+
+@pytest.mark.parametrize("resn", ["HID", "HISA", "HISD"])
+def test_protonate_his_delta_aliases(resn):
+    """Names the PDB reader double bonds CE1=NE2 titrate on NE2."""
+    from pymol.editing import _get_formal_charge
+
+    assert _get_formal_charge(resn, 'NE2', 0, 5.0) == 1
+    assert _get_formal_charge(resn, 'ND1', 0, 5.0) == 0
+    assert _get_formal_charge(resn, 'NE2', 0, 7.0) == 0
+    assert _get_formal_charge(resn, 'ND1', 0, 7.0) == 0
+
+
 def _build_single_nuc(nuc_acid, nuc_type, obj_name, chain='A'):
     """Helper: build a single nucleotide and return the object name.
 

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -149,6 +149,24 @@ def test_protonate_fallback_low_pH():
         "His ND1 should be protonated at pH 2.0"
 
 
+def test_protonate_fallback_pH_transitions():
+    """Formal charges should drive h_add across textbook pKa thresholds."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("EHK", "m1")
+
+    expected = [
+        (3.5, 30),
+        (5.9, 29),
+        (6.1, 28),
+        (13.0, 27),
+    ]
+
+    for pH, hydrogen_count in expected:
+        _protonate_fallback("m1", "m1", pH, 0, 1, _self=cmd)
+        assert cmd.count_atoms("m1 and hydro") == hydrogen_count
+
+
 def _build_single_nuc(nuc_acid, nuc_type, obj_name, chain='A'):
     """Helper: build a single nucleotide and return the object name.
 

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -288,6 +288,47 @@ def test_protonate_his_delta_aliases(resn):
     assert _get_formal_charge(resn, 'ND1', 0, 7.0) == 0
 
 
+def test_protonate_titratable_selection_matches_table():
+    """The alter selection must cover every atom the pKa table can change."""
+    from pymol.editing import (_HIS_TAUTOMER, _TITRATABLE_PKA_FORMAL_CHARGE,
+                               _TITRATABLE_SELECTION)
+
+    expected = set()
+    for resn, name in _TITRATABLE_PKA_FORMAL_CHARGE:
+        for alias, tautomer in _HIS_TAUTOMER.items():
+            if tautomer == resn:
+                expected.add((alias, name))
+        if resn not in _HIS_TAUTOMER.values():
+            expected.add((resn, name))
+
+    cmd.fab("EHKRYCDA", "m1")
+    matched = set()
+    for alias in sorted(_HIS_TAUTOMER):
+        cmd.alter("m1 and resi 2", f"resn = {alias!r}")
+        cmd.iterate(f"(m1) and ({_TITRATABLE_SELECTION})",
+                    "matched.add((resn, name))", space={"matched": matched})
+
+    assert matched == expected
+
+
+def test_protonate_fallback_preserves_untitrated_chemistry():
+    """Writing formal_charge clears chemFlag, so only titratable atoms may
+    be written - otherwise set_geometry corrections are silently discarded."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("GD", "m1")
+    cmd.remove("m1 and hydro")
+    # planar with valence 3: CA has N and C as neighbours, so exactly one H
+    cmd.set_geometry("m1 and resi 1 and name CA", 2, 3)
+
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+
+    assert cmd.count_atoms(
+        "m1 and hydro and neighbor (resi 1 and name CA)") == 1
+    assert cmd.count_atoms("m1 and hydro and neighbor (name OD1+OD2)") == 0
+    assert _formal_charges("m1 and name OD2") == [-1]
+
+
 def _build_single_nuc(nuc_acid, nuc_type, obj_name, chain='A'):
     """Helper: build a single nucleotide and return the object name.
 

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -289,26 +289,46 @@ def test_protonate_his_delta_aliases(resn):
 
 
 def test_protonate_titratable_selection_matches_table():
-    """The alter selection must cover every atom the pKa table can change."""
-    from pymol.editing import (_HIS_TAUTOMER, _TITRATABLE_PKA_FORMAL_CHARGE,
-                               _TITRATABLE_SELECTION)
+    """The alter selection must match an atom exactly when
+    _get_formal_charge has a pKa for it - missing atoms are never titrated,
+    extra atoms lose their chemFlag for nothing."""
+    from pymol.editing import (_HIS_TAUTOMER, _TITRATABLE_SELECTION,
+                               _get_formal_charge)
 
-    expected = set()
-    for resn, name in _TITRATABLE_PKA_FORMAL_CHARGE:
-        for alias, tautomer in _HIS_TAUTOMER.items():
-            if tautomer == resn:
-                expected.add((alias, name))
-        if resn not in _HIS_TAUTOMER.values():
-            expected.add((resn, name))
+    sentinel = object()
 
     cmd.fab("EHKRYCDA", "m1")
-    matched = set()
+    seen, matched = set(), set()
     for alias in sorted(_HIS_TAUTOMER):
         cmd.alter("m1 and resi 2", f"resn = {alias!r}")
+        cmd.iterate("m1", "acc.add((resn, name))", space={"acc": seen})
         cmd.iterate(f"(m1) and ({_TITRATABLE_SELECTION})",
-                    "matched.add((resn, name))", space={"matched": matched})
+                    "acc.add((resn, name))", space={"acc": matched})
 
+    expected = {
+        (resn, name) for resn, name in seen
+        if _get_formal_charge(resn, name, sentinel, 7.0) is not sentinel
+    }
+
+    assert matched
     assert matched == expected
+
+
+def test_protonate_fallback_lowercase_resn():
+    """PyMOL selections ignore case, so the pKa lookup must too."""
+    from pymol.editing import _protonate_fallback, _get_formal_charge
+
+    assert _get_formal_charge('his', 'nd1', 0, 5.0) == 1
+    assert _get_formal_charge('asp', 'od2', 0, 7.0) == -1
+
+    cmd.fab("D", "m1")
+    cmd.alter("m1", "resn = resn.lower()")
+    cmd.alter("m1", "name = name.lower()")
+
+    _protonate_fallback("m1", "m1", 7.0, 0, 1, _self=cmd)
+
+    assert cmd.count_atoms("m1 and hydro and neighbor (name OD1+OD2)") == 0
+    assert _formal_charges("m1 and name OD2") == [-1]
 
 
 def test_protonate_fallback_preserves_untitrated_chemistry():

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -174,6 +174,12 @@ def _formal_charges(selection):
     return charges
 
 
+def _resns(selection):
+    names = set()
+    cmd.iterate(selection, "names.add(resn)", space={"names": names})
+    return names
+
+
 def test_protonate_fallback_free_cysteine():
     """A free thiol loses its H and turns into a thiolate above pKa 8.18."""
     from pymol.editing import _protonate_fallback
@@ -228,14 +234,18 @@ def test_protonate_fallback_tyrosine_and_arginine():
     assert _formal_charges("m1 and name NH1") == [0]
 
 
-def _build_his_tautomer(resn, obj_name):
-    """Build a histidine and round-trip it through PDB under `resn` so that
-    the reader assigns the imidazole bond orders that name implies."""
-    cmd.fab("H", "_his_tmp")
-    cmd.alter("_his_tmp", f"resn = {resn!r}")
-    pdbstr = cmd.get_pdbstr("_his_tmp and not hydro")
-    cmd.delete("_his_tmp")
+def _build_pdb_residue(seq, resn, obj_name):
+    """Build `seq`, rename it to `resn` and round-trip it through PDB so that
+    the reader assigns the bond orders and formal charges that name implies."""
+    cmd.fab(seq, "_prot_tmp")
+    cmd.alter("_prot_tmp", f"resn = {resn!r}")
+    pdbstr = cmd.get_pdbstr("_prot_tmp and not hydro")
+    cmd.delete("_prot_tmp")
     cmd.read_pdbstr(pdbstr, obj_name)
+
+
+def _build_his_tautomer(resn, obj_name):
+    _build_pdb_residue("H", resn, obj_name)
 
 
 @pytest.mark.parametrize("resn,neutral_h_on", [
@@ -292,18 +302,26 @@ def test_protonate_titratable_selection_matches_table():
     """The alter selection must match an atom exactly when
     _get_formal_charge has a pKa for it - missing atoms are never titrated,
     extra atoms lose their chemFlag for nothing."""
-    from pymol.editing import (_HIS_TAUTOMER, _TITRATABLE_SELECTION,
+    from pymol.editing import (_RESN_ALIAS, _TITRATABLE_SELECTION,
                                _get_formal_charge)
 
     sentinel = object()
 
     cmd.fab("EHKRYCDA", "m1")
+    # the residue of "EHKRYCDA" whose atom names each canonical name expects
+    resi_of = {'GLU': 1, 'HIE': 2, 'HID': 2, 'LYS': 3,
+               'ARG': 4, 'TYR': 5, 'CYS': 6, 'ASP': 7}
     seen, matched = set(), set()
-    for alias in sorted(_HIS_TAUTOMER):
-        cmd.alter("m1 and resi 2", f"resn = {alias!r}")
+
+    def snapshot():
         cmd.iterate("m1", "acc.add((resn, name))", space={"acc": seen})
         cmd.iterate(f"(m1) and ({_TITRATABLE_SELECTION})",
                     "acc.add((resn, name))", space={"acc": matched})
+
+    snapshot()
+    for alias, canonical in sorted(_RESN_ALIAS.items()):
+        cmd.alter(f"m1 and resi {resi_of[canonical]}", f"resn = {alias!r}")
+        snapshot()
 
     expected = {
         (resn, name) for resn, name in seen
@@ -347,6 +365,85 @@ def test_protonate_fallback_preserves_untitrated_chemistry():
         "m1 and hydro and neighbor (resi 1 and name CA)") == 1
     assert cmd.count_atoms("m1 and hydro and neighbor (name OD1+OD2)") == 0
     assert _formal_charges("m1 and name OD2") == [-1]
+
+
+@pytest.mark.parametrize("seq,alias,name,acidic,basic", [
+    ("R", "ARGP", "NH1", 1, 0),
+    ("K", "LYSP", "NZ", 1, 0),
+    ("D", "ASPM", "OD2", 0, -1),
+    ("E", "GLUM", "OE2", 0, -1),
+])
+def test_protonate_fallback_reader_charged_aliases(seq, alias, name,
+                                                   acidic, basic):
+    """The PDB reader pre-charges the ARGP/ASPM/GLUM/LYSP spellings, so the
+    fallback has to titrate them instead of leaving the reader's charge."""
+    from pymol.editing import _protonate_fallback
+
+    _build_pdb_residue(seq, alias, "m1")
+    assert _resns("m1") == {alias}
+
+    _protonate_fallback("m1", "m1", 1.0, 0, 1, _self=cmd)
+    assert _formal_charges(f"m1 and name {name}") == [acidic]
+
+    _protonate_fallback("m1", "m1", 13.0, 0, 1, _self=cmd)
+    assert _formal_charges(f"m1 and name {name}") == [basic]
+
+
+@pytest.mark.parametrize("resn", ["HIP", "HISH", "HISP"])
+def test_protonate_fallback_demoted_cation_is_renamed(resn):
+    """The PDB reader restores ND1 = +1 for these names whatever the file
+    says, so a demoted residue has to be renamed to survive a round trip."""
+    from pymol.editing import _protonate_fallback
+
+    _build_his_tautomer(resn, "m1")
+
+    # below pKa 6.0 the name still describes the residue, so it is kept
+    _protonate_fallback("m1", "m1", 5.0, 0, 1, _self=cmd)
+    assert _resns("m1") == {resn}
+    assert sum(_formal_charges("m1 and name ND1+NE2")) == 1
+    assert cmd.count_atoms("m1 and hydro and neighbor (name ND1+NE2)") == 2
+
+    # above it, the name would resurrect the proton the fallback removed
+    _protonate_fallback("m1", "m1", 7.4, 0, 1, _self=cmd)
+    assert _resns("m1") == {"HIS"}
+    assert _formal_charges("m1 and name ND1+NE2") == [0, 0]
+
+    cmd.read_pdbstr(cmd.get_pdbstr("m1"), "m2")
+    assert _formal_charges("m2 and name ND1+NE2") == [0, 0]
+    assert cmd.count_atoms("m2 and hydro and neighbor (name ND1)") == 0
+
+
+def test_protonate_fallback_thioether_crosslink_stays_neutral():
+    """The free-thiol test has to be connectivity based: an SG bridged to
+    another residue's CB is no more ionizable than a disulfide."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("CGC", "m1")
+    cmd.bond("m1 and resi 1 and name SG", "m1 and resi 3 and name CB")
+
+    _protonate_fallback("m1", "m1", 13.0, 0, 1, _self=cmd)
+
+    assert _formal_charges("m1 and resi 1 and name SG") == [0]
+    assert cmd.count_atoms(
+        "m1 and hydro and neighbor (resi 1 and name SG)") == 0
+    # the cysteine which is still free keeps titrating
+    assert _formal_charges("m1 and resi 3 and name SG") == [-1]
+
+
+def test_protonate_fallback_keeps_unselected_hydrogens():
+    """Only the selection is rebuilt, so only its hydrogens may be stripped."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("AD", "m1")
+    cmd.h_add("m1")
+    untouched = cmd.count_atoms("m1 and hydro and resi 1")
+    assert untouched > 0
+
+    _protonate_fallback("m1 and resi 2", "m1", 13.0, 0, 1, _self=cmd)
+
+    assert cmd.count_atoms("m1 and hydro and resi 1") == untouched
+    assert _formal_charges("m1 and name OD2") == [-1]
+    assert cmd.count_atoms("m1 and hydro and neighbor (name OD1+OD2)") == 0
 
 
 def _build_single_nuc(nuc_acid, nuc_type, obj_name, chain='A'):

--- a/testing/tests/api/test_editing.py
+++ b/testing/tests/api/test_editing.py
@@ -213,6 +213,21 @@ def test_protonate_fallback_disulfide_stays_neutral():
     assert _formal_charges("m1 and name SG") == [0, 0]
 
 
+def test_protonate_fallback_disulfide_in_discrete_object():
+    """A discrete object keeps each atom in one state only, so the bridged
+    cysteines outside the current state must still be recognized."""
+    from pymol.editing import _protonate_fallback
+
+    cmd.fab("CGC", "m1")
+    cmd.bond("m1 and resi 1 and name SG", "m1 and resi 3 and name SG")
+    cmd.create("m2", "m1", 1, 1, discrete=1)
+    cmd.create("m2", "m2", 1, 2, discrete=1)
+
+    _protonate_fallback("m2", "m2", 13.0, 0, 1, _self=cmd)
+
+    assert _formal_charges("m2 and name SG") == [0, 0, 0, 0]
+
+
 def test_protonate_fallback_tyrosine_and_arginine():
     """Tyr and Arg bracket the pH range covered by the fallback table."""
     from pymol.editing import _protonate_fallback


### PR DESCRIPTION
## Summary

Use pH-dependent formal charges to drive fallback protonation before `h_add`, with correct handling for standard residue aliases, cysteine/disulfides, histidine, and partial selections.

## Tests

- Built with the project pixi toolchain.
- Verified EHK hydrogen counts: 30/29/28/27 at pH 3.5/5.9/6.1/13.0.
- Targeted protonation regressions, documentation, lint, and CI passed.

Fixes #500 
