### PR TITLE
feat(exporting): add native glTF 2.0 and GLB export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,9 @@ jobs:
             libglm-dev \
             libmsgpack-dev \
             libnetcdf-dev \
+            nlohmann-json3-dev \
             libpng-dev \
             libxml2-dev
-
-    - name: Install collada2gltf
-      run: |
-        wget -nv https://anaconda.org/schrodinger/collada2gltf/2.1.4/download/linux-64/collada2gltf-2.1.4-h6bb024c_0.tar.bz2
-        sudo tar xf collada2gltf-*.tar.bz2 -C / bin/collada2gltf
 
     - name: Get additional sources
       run: |
@@ -84,13 +80,13 @@ jobs:
             python=${{ matrix.python-version }} `
             pip `
             catch2=2.13.3 `
-            collada2gltf `
             freetype `
             glew `
             glm `
             libpng `
             libxml2-devel `
             libnetcdf `
+            nlohmann_json
 
     - name: Get additional sources
       run: |
@@ -143,13 +139,13 @@ jobs:
             python=${{ matrix.python-version }} \
             pip \
             catch2=2.13.3 \
-            collada2gltf \
             freetype \
             glew \
             glm \
             libpng \
             libxml2-devel \
-            libnetcdf
+            libnetcdf \
+            nlohmann_json
 
     - name: Get additional sources
       run: |
@@ -169,4 +165,3 @@ jobs:
       run: |
         source activate $CONDA_ENV_NAME
         pymol -ckqy testing/testing.py --run all
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build
       run: |
         pip install --upgrade pip
-        pip install -v --config-settings testing=True '.[dev]'
+        pip install -v --config-settings testing=True --config-settings json=True '.[dev]'
       env:
         DEBUG: 1
 
@@ -101,7 +101,7 @@ jobs:
     - name: Build PyMOL
       run: |
         conda activate $env:CONDA_ENV_NAME
-        pip install -v --config-settings testing=True .[dev]
+        pip install -v --config-settings testing=True --config-settings json=True .[dev]
 
     - name: Test
       run: |
@@ -159,7 +159,7 @@ jobs:
       run: |
         source activate $CONDA_ENV_NAME
         export MACOSX_DEPLOYMENT_TARGET=12.0
-        pip install -v --config-settings testing=True '.[dev]'
+        pip install -v --config-settings testing=True --config-settings json=True '.[dev]'
 
     - name: Test
       run: |

--- a/INSTALL
+++ b/INSTALL
@@ -28,6 +28,7 @@ REQUIREMENTS
     - catch2 (optional, enable with --testing=true)
     - openvr 1.0.x (optional, enable with --openvr=true)
     - libnetcdf (optional, disable with --vmd-plugins=no)
+    - nlohmann-json 3.10+ (for glTF 2.0 and GLB export)
 
 SETUP OPTIONS
 

--- a/INSTALL
+++ b/INSTALL
@@ -28,7 +28,8 @@ REQUIREMENTS
     - catch2 (optional, enable with --testing=true)
     - openvr 1.0.x (optional, enable with --openvr=true)
     - libnetcdf (optional, disable with --vmd-plugins=no)
-    - nlohmann-json 3.10+ (for glTF 2.0 and GLB export)
+    - nlohmann-json 3.10+ (optional, for glTF 2.0 and GLB export,
+        enable with --json=true)
 
 SETUP OPTIONS
 

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -95,12 +95,27 @@ struct MeshGroup {
    */
   void addVertex(const float* pos, const float* norm, const float* col)
   {
+    float unit_norm[3] = {norm[0], norm[1], norm[2]};
+    const float norm_sq = unit_norm[0] * unit_norm[0] +
+        unit_norm[1] * unit_norm[1] + unit_norm[2] * unit_norm[2];
+    if (std::isfinite(norm_sq) &&
+        norm_sq > std::numeric_limits<float>::epsilon()) {
+      const float inv_norm = 1.0f / std::sqrt(norm_sq);
+      unit_norm[0] *= inv_norm;
+      unit_norm[1] *= inv_norm;
+      unit_norm[2] *= inv_norm;
+    } else {
+      unit_norm[0] = 0.0f;
+      unit_norm[1] = 0.0f;
+      unit_norm[2] = 1.0f;
+    }
+
     positions.push_back(pos[0]);
     positions.push_back(pos[1]);
     positions.push_back(pos[2]);
-    normals.push_back(norm[0]);
-    normals.push_back(norm[1]);
-    normals.push_back(norm[2]);
+    normals.push_back(unit_norm[0]);
+    normals.push_back(unit_norm[1]);
+    normals.push_back(unit_norm[2]);
     colors.push_back(srgbToLinear(col[0]));
     colors.push_back(srgbToLinear(col[1]));
     colors.push_back(srgbToLinear(col[2]));

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -11,9 +11,12 @@
 #include "os_predef.h"
 #include "os_std.h"
 
-#include "CGO.h"
 #include "Feedback.h"
 #include "GLTF.h"
+
+#ifdef _HAVE_JSON
+
+#include "CGO.h"
 #include "MemoryDebug.h"
 #include "Ray.h"
 #include "Scene.h"
@@ -174,7 +177,8 @@ static MeshGroup& findOrCreateGroup(std::vector<MeshGroup>& groups, float trans)
  */
 static void addSphere(MeshGroup& group, const CPrimitive* prim, PyMOLGlobals* G)
 {
-  int sq = SettingGetGlobal_i(G, cSetting_sphere_quality);
+  int sq = std::clamp(SettingGetGlobal_i(G, cSetting_sphere_quality), 0,
+      NUMBER_OF_SPHERE_LEVELS - 1);
   SphereRec* sp = G->Sphere->Sphere[sq];
 
   /* Use the pre-computed triangle mesh (Tri array) for spheres.
@@ -739,10 +743,10 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
 
   /* Ray trace - expand all objects into primitives */
   RayExpandPrimitives(I);
-  RayTransformFirst(I, 0, false);
 
   /* Collect primitives into mesh groups by transparency */
   std::vector<MeshGroup> groups;
+  int n_unsupported = 0;
 
   for (int a = 0; a < I->NPrimitive; a++) {
     CPrimitive* prim = I->Primitive + a;
@@ -766,9 +770,17 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
 
     case cPrimCharacter:
     case cPrimEllipsoid:
-      /* Not supported - skip silently (same as COLLADA) */
+      /* Not supported yet */
+      n_unsupported++;
       break;
     }
+  }
+
+  if (n_unsupported) {
+    PRINTFB(G, FB_Ray, FB_Warnings)
+    " GLB-Warning: Skipped %d unsupported primitive(s) "
+    "(text labels and ellipsoids are not exported).\n",
+        n_unsupported ENDFB(G);
   }
 
   /* Remove empty groups */
@@ -851,3 +863,5 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
   " GLB: exported %d mesh group(s), %u bytes total.\n", (int) groups.size(),
       total_size ENDFB(G);
 }
+
+#endif // _HAVE_JSON

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <memory>
@@ -42,6 +43,27 @@ static constexpr std::uint32_t GLB_HEADER_SIZE = 12;
 static constexpr std::uint32_t GLB_CHUNK_HEADER_SIZE = 8;
 
 static constexpr float TRANS_PRECISION = 0.01f;
+
+/* A GLB container addresses everything with 32-bit offsets */
+static constexpr std::uint64_t GLB_MAX_SIZE = 0xFFFFFFFFull;
+
+/**
+ * Convert a display-space (sRGB) color channel to linear space.
+ * @param c channel value, expected in the 0-1 range
+ * @return the linear-space channel value
+ * @note PyMOL color components are display-space values handed straight to
+ *   OpenGL, whereas glTF 2.0 defines COLOR_0 and baseColorFactor as linear.
+ */
+static float srgbToLinear(float c)
+{
+  if (c <= 0.0f)
+    return 0.0f;
+  if (c >= 1.0f)
+    return 1.0f;
+  if (c <= 0.04045f)
+    return c / 12.92f;
+  return std::pow((c + 0.055f) / 1.055f, 2.4f);
+}
 
 /**
  * Collects triangles that share the same material, grouped by transparency
@@ -67,7 +89,9 @@ struct MeshGroup {
    * box.
    * @param pos xyz position (3 floats)
    * @param norm xyz normal (3 floats)
-   * @param col rgb color (3 floats, 0-1 range)
+   * @param col rgb color (3 floats, 0-1 range, display space)
+   * @note The color is converted from display (sRGB) to linear space, which
+   *   is what glTF 2.0 expects for COLOR_0.
    */
   void addVertex(const float* pos, const float* norm, const float* col)
   {
@@ -77,9 +101,9 @@ struct MeshGroup {
     normals.push_back(norm[0]);
     normals.push_back(norm[1]);
     normals.push_back(norm[2]);
-    colors.push_back(col[0]);
-    colors.push_back(col[1]);
-    colors.push_back(col[2]);
+    colors.push_back(srgbToLinear(col[0]));
+    colors.push_back(srgbToLinear(col[1]));
+    colors.push_back(srgbToLinear(col[2]));
 
     for (int i = 0; i < 3; i++) {
       if (pos[i] < min_pos[i])
@@ -381,49 +405,59 @@ static void addTriangle(MeshGroup& group, const CPrimitive* prim)
  * @return size rounded up to 4-byte boundary
  * @note Required by the GLB spec for chunk alignment.
  */
-static std::uint32_t alignTo4(std::uint32_t size)
+static std::uint64_t alignTo4(std::uint64_t size)
 {
-  return (size + 3) & ~3u;
+  return (size + 3) & ~UINT64_C(3);
 }
 
 /**
- * Write a uint32 in little-endian byte order to a byte vector.
- * @param[out] out byte vector to append to
+ * @return true if the host stores multi-byte integers least significant byte
+ *   first, in which case 32-bit arrays can be copied verbatim into the GLB
+ *   binary chunk.
+ */
+static bool isLittleEndianHost()
+{
+  const std::uint32_t one = 1;
+  std::uint8_t first_byte;
+  std::memcpy(&first_byte, &one, 1);
+  return first_byte == 1;
+}
+
+/**
+ * Write a uint32 in little-endian byte order.
+ * @param[out] dest destination, must have room for 4 bytes
  * @param val 32-bit value to write
+ * @return pointer just past the written bytes
  */
-static void writeU32(std::vector<std::uint8_t>& out, std::uint32_t val)
+static char* writeU32(char* dest, std::uint32_t val)
 {
-  out.push_back(val & 0xFF);
-  out.push_back((val >> 8) & 0xFF);
-  out.push_back((val >> 16) & 0xFF);
-  out.push_back((val >> 24) & 0xFF);
+  dest[0] = static_cast<char>(val & 0xFF);
+  dest[1] = static_cast<char>((val >> 8) & 0xFF);
+  dest[2] = static_cast<char>((val >> 16) & 0xFF);
+  dest[3] = static_cast<char>((val >> 24) & 0xFF);
+  return dest + 4;
 }
 
 /**
- * Append floats to a byte vector in little-endian byte order.
- * @param[out] out byte vector to append to
- * @param data source float data
+ * Copy an array of 32-bit elements (float or uint32) in little-endian byte
+ * order.
+ * @param[out] dest destination, must have room for 4 * data.size() bytes
+ * @param data source data
  */
-static void appendFloats(
-    std::vector<std::uint8_t>& out, const std::vector<float>& data)
+template <typename T>
+static void writeU32Array(char* dest, const std::vector<T>& data)
 {
-  for (float f : data) {
-    std::uint32_t bits;
-    std::memcpy(&bits, &f, sizeof(float));
-    writeU32(out, bits);
+  static_assert(sizeof(T) == 4, "expected 32-bit elements");
+
+  if (isLittleEndianHost()) {
+    std::memcpy(dest, data.data(), data.size() * sizeof(T));
+    return;
   }
-}
 
-/**
- * Append uint32s to a byte vector in little-endian byte order.
- * @param[out] out byte vector to append to
- * @param data source uint32 data
- */
-static void appendU32s(
-    std::vector<std::uint8_t>& out, const std::vector<std::uint32_t>& data)
-{
-  for (std::uint32_t v : data) {
-    writeU32(out, v);
+  for (const T& value : data) {
+    std::uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(T));
+    dest = writeU32(dest, bits);
   }
 }
 
@@ -447,52 +481,62 @@ struct GroupBufferInfo {
 };
 
 /**
- * Pack all mesh groups' vertex attributes and indices into a single contiguous
- * binary buffer suitable for the GLB BIN chunk.
+ * Compute where each mesh group's vertex attributes and indices live inside
+ * the single contiguous binary buffer of the GLB BIN chunk.
  *
  * Layout per group: [positions][normals][colors][indices]
  *
  * @param groups mesh groups containing vertex/index data
  * @param[out] infos byte offset and length for each group's attributes
- * @return the packed binary buffer
+ * @return the total binary buffer size in bytes
  * @note All sections are naturally 4-byte aligned (float and uint32 data).
+ *   The result may exceed what a GLB container can address; the caller is
+ *   responsible for rejecting it.
  */
-static std::vector<std::uint8_t> buildBinaryBuffer(
+static std::uint64_t computeBufferLayout(
     const std::vector<MeshGroup>& groups, std::vector<GroupBufferInfo>& infos)
 {
-  std::vector<std::uint8_t> buffer;
+  std::uint64_t offset = 0;
   infos.resize(groups.size());
+
+  auto place = [&offset](BufferViewInfo& view, std::uint64_t length) {
+    view.offset = static_cast<std::uint32_t>(offset);
+    view.length = static_cast<std::uint32_t>(length);
+    offset += length;
+  };
 
   for (size_t g = 0; g < groups.size(); g++) {
     const auto& mesh = groups[g];
     auto& info = infos[g];
 
-    /* Positions */
-    info.positions.offset = static_cast<std::uint32_t>(buffer.size());
-    info.positions.length =
-        static_cast<std::uint32_t>(mesh.positions.size() * sizeof(float));
-    appendFloats(buffer, mesh.positions);
-
-    /* Normals */
-    info.normals.offset = static_cast<std::uint32_t>(buffer.size());
-    info.normals.length =
-        static_cast<std::uint32_t>(mesh.normals.size() * sizeof(float));
-    appendFloats(buffer, mesh.normals);
-
-    /* Colors */
-    info.colors.offset = static_cast<std::uint32_t>(buffer.size());
-    info.colors.length =
-        static_cast<std::uint32_t>(mesh.colors.size() * sizeof(float));
-    appendFloats(buffer, mesh.colors);
-
-    /* Indices */
-    info.indices.offset = static_cast<std::uint32_t>(buffer.size());
-    info.indices.length =
-        static_cast<std::uint32_t>(mesh.indices.size() * sizeof(std::uint32_t));
-    appendU32s(buffer, mesh.indices);
+    place(info.positions, mesh.positions.size() * sizeof(float));
+    place(info.normals, mesh.normals.size() * sizeof(float));
+    place(info.colors, mesh.colors.size() * sizeof(float));
+    place(info.indices, mesh.indices.size() * sizeof(std::uint32_t));
   }
 
-  return buffer;
+  return offset;
+}
+
+/**
+ * Serialize all mesh groups' vertex attributes and indices into the GLB BIN
+ * chunk payload, following the layout from computeBufferLayout().
+ * @param groups mesh groups containing vertex/index data
+ * @param infos buffer layout info from computeBufferLayout()
+ * @param[out] dest destination, must have room for the full buffer
+ */
+static void writeBinaryBuffer(const std::vector<MeshGroup>& groups,
+    const std::vector<GroupBufferInfo>& infos, char* dest)
+{
+  for (size_t g = 0; g < groups.size(); g++) {
+    const auto& mesh = groups[g];
+    const auto& info = infos[g];
+
+    writeU32Array(dest + info.positions.offset, mesh.positions);
+    writeU32Array(dest + info.normals.offset, mesh.normals);
+    writeU32Array(dest + info.colors.offset, mesh.colors);
+    writeU32Array(dest + info.indices.offset, mesh.indices);
+  }
 }
 
 /**
@@ -512,11 +556,7 @@ static std::string buildGLTFJson(const std::vector<MeshGroup>& groups,
   /* Asset */
   root["asset"] = {
       {"version", "2.0"},
-#ifdef _PyMOL_VERSION
       {"generator", "PyMOL " _PyMOL_VERSION},
-#else
-      {"generator", "PyMOL"},
-#endif
   };
 
   /* Scene */
@@ -554,7 +594,8 @@ static std::string buildGLTFJson(const std::vector<MeshGroup>& groups,
     } else {
       mat["alphaMode"] = "OPAQUE";
     }
-    mat["doubleSided"] = false;
+    /* PyMOL draws this geometry without back-face culling */
+    mat["doubleSided"] = true;
     materials.push_back(mat);
 
     /* Buffer views: positions */
@@ -729,58 +770,73 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
     return;
   }
 
-  /* Build binary buffer */
+  /* Lay out the binary buffer without materializing it yet */
   std::vector<GroupBufferInfo> buffer_infos;
-  auto bin_buffer = buildBinaryBuffer(groups, buffer_infos);
+  std::uint64_t bin_len = computeBufferLayout(groups, buffer_infos);
+  std::uint64_t bin_padded = alignTo4(bin_len);
+
+  if (bin_padded > GLB_MAX_SIZE) {
+    PRINTFB(G, FB_Ray, FB_Errors)
+    " GLB-Error: Geometry is too large for the GLB container "
+    "(%llu bytes, limit is %llu).\n",
+        (unsigned long long) bin_padded,
+        (unsigned long long) GLB_MAX_SIZE ENDFB(G);
+    VLASize(*vla_ptr, char, 0);
+    return;
+  }
 
   /* Build JSON */
-  std::string json_str = buildGLTFJson(
-      groups, buffer_infos, static_cast<std::uint32_t>(bin_buffer.size()));
+  std::string json_str =
+      buildGLTFJson(groups, buffer_infos, static_cast<std::uint32_t>(bin_len));
 
   /* Pad JSON to 4-byte alignment with spaces */
-  std::uint32_t json_len = static_cast<std::uint32_t>(json_str.size());
-  std::uint32_t json_padded = alignTo4(json_len);
-  json_str.resize(json_padded, ' ');
+  std::uint64_t json_len = json_str.size();
+  std::uint64_t json_padded = alignTo4(json_len);
 
-  /* Pad binary buffer to 4-byte alignment with zeros */
-  std::uint32_t bin_len = static_cast<std::uint32_t>(bin_buffer.size());
-  std::uint32_t bin_padded = alignTo4(bin_len);
-  bin_buffer.resize(bin_padded, 0);
+  std::uint64_t total = GLB_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE + json_padded +
+                        GLB_CHUNK_HEADER_SIZE + bin_padded;
 
-  /* Assemble GLB */
-  std::uint32_t total_size = GLB_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE +
-                             json_padded + GLB_CHUNK_HEADER_SIZE + bin_padded;
+  if (total > GLB_MAX_SIZE) {
+    PRINTFB(G, FB_Ray, FB_Errors)
+    " GLB-Error: Scene is too large for the GLB container "
+    "(%llu bytes, limit is %llu).\n",
+        (unsigned long long) total, (unsigned long long) GLB_MAX_SIZE ENDFB(G);
+    VLASize(*vla_ptr, char, 0);
+    return;
+  }
 
-  std::vector<std::uint8_t> glb;
-  glb.reserve(total_size);
+  std::uint32_t total_size = static_cast<std::uint32_t>(total);
 
-  /* Header */
-  writeU32(glb, GLB_MAGIC);
-  writeU32(glb, GLB_VERSION);
-  writeU32(glb, total_size);
-
-  /* JSON chunk */
-  writeU32(glb, json_padded);
-  writeU32(glb, GLB_CHUNK_JSON);
-  glb.insert(glb.end(), json_str.begin(), json_str.end());
-
-  /* BIN chunk */
-  writeU32(glb, bin_padded);
-  writeU32(glb, GLB_CHUNK_BIN);
-  glb.insert(glb.end(), bin_buffer.begin(), bin_buffer.end());
-
-  /* Copy to VLA output */
+  /* Assemble the GLB directly in the output VLA */
   char* vla = *vla_ptr;
 
-  VLACheck(vla, char, total_size);
+  VLASize(vla, char, total_size);
   if (!vla) {
     PRINTFB(G, FB_Ray, FB_Errors)
     " GLB-Error: Failed to allocate output buffer.\n" ENDFB(G);
     *vla_ptr = nullptr;
     return;
   }
-  memcpy(vla, glb.data(), total_size);
-  VLASize(vla, char, total_size);
+
+  char* out = vla;
+
+  /* Header */
+  out = writeU32(out, GLB_MAGIC);
+  out = writeU32(out, GLB_VERSION);
+  out = writeU32(out, total_size);
+
+  /* JSON chunk */
+  out = writeU32(out, static_cast<std::uint32_t>(json_padded));
+  out = writeU32(out, GLB_CHUNK_JSON);
+  std::memcpy(out, json_str.data(), json_len);
+  std::memset(out + json_len, ' ', json_padded - json_len);
+  out += json_padded;
+
+  /* BIN chunk */
+  out = writeU32(out, static_cast<std::uint32_t>(bin_padded));
+  out = writeU32(out, GLB_CHUNK_BIN);
+  writeBinaryBuffer(groups, buffer_infos, out);
+  std::memset(out + bin_len, 0, bin_padded - bin_len);
 
   *vla_ptr = vla;
 

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -722,11 +722,9 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
 {
   PyMOLGlobals* G = I->G;
 
-  int identity = (SettingGetGlobal_i(G, cSetting_geometry_export_mode) == 1);
-
   /* Ray trace - expand all objects into primitives */
   RayExpandPrimitives(I);
-  RayTransformFirst(I, 0, identity);
+  RayTransformFirst(I, 0, false);
 
   /* Collect primitives into mesh groups by transparency */
   std::vector<MeshGroup> groups;
@@ -811,12 +809,6 @@ void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
   char* vla = *vla_ptr;
 
   VLASize(vla, char, total_size);
-  if (!vla) {
-    PRINTFB(G, FB_Ray, FB_Errors)
-    " GLB-Error: Failed to allocate output buffer.\n" ENDFB(G);
-    *vla_ptr = nullptr;
-    return;
-  }
 
   char* out = vla;
 

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -100,7 +100,8 @@ struct MeshGroup {
   {
     float unit_norm[3] = {norm[0], norm[1], norm[2]};
     const float norm_sq = unit_norm[0] * unit_norm[0] +
-        unit_norm[1] * unit_norm[1] + unit_norm[2] * unit_norm[2];
+                          unit_norm[1] * unit_norm[1] +
+                          unit_norm[2] * unit_norm[2];
     if (std::isfinite(norm_sq) &&
         norm_sq > std::numeric_limits<float>::epsilon()) {
       const float inv_norm = 1.0f / std::sqrt(norm_sq);

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -563,7 +563,7 @@ static void writeBinaryBuffer(const std::vector<MeshGroup>& groups,
  * and PBR material per MeshGroup, with POSITION/NORMAL/COLOR_0 vertex
  * attributes and UNSIGNED_INT indices.
  * @param groups mesh groups (one per transparency level)
- * @param infos buffer layout info from buildBinaryBuffer()
+ * @param infos buffer layout info from computeBufferLayout()
  * @param buffer_size total size of the binary buffer in bytes
  * @return serialized JSON string
  */

--- a/layer1/GLTF.cpp
+++ b/layer1/GLTF.cpp
@@ -1,0 +1,790 @@
+/*
+ * PyMOL glTF 2.0 / GLB export
+ *
+ * Exports the current scene as a GLB (binary glTF 2.0) file.
+ * Uses the ray-tracing primitive pipeline to generate triangle meshes,
+ * then serializes them into the GLB container format.
+ *
+ * (c) 2026 Schrodinger, Inc.
+ */
+
+#include "os_predef.h"
+#include "os_std.h"
+
+#include "CGO.h"
+#include "Feedback.h"
+#include "GLTF.h"
+#include "MemoryDebug.h"
+#include "Ray.h"
+#include "Scene.h"
+#include "Setting.h"
+#include "Sphere.h"
+#include "Util.h"
+#include "Version.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <vector>
+
+using json = nlohmann::json;
+
+/* GLB constants */
+static constexpr std::uint32_t GLB_MAGIC = 0x46546C67; /* "glTF" */
+static constexpr std::uint32_t GLB_VERSION = 2;
+static constexpr std::uint32_t GLB_CHUNK_JSON = 0x4E4F534A; /* "JSON" */
+static constexpr std::uint32_t GLB_CHUNK_BIN = 0x004E4942;  /* "BIN\0" */
+static constexpr std::uint32_t GLB_HEADER_SIZE = 12;
+static constexpr std::uint32_t GLB_CHUNK_HEADER_SIZE = 8;
+
+static constexpr float TRANS_PRECISION = 0.01f;
+
+/**
+ * Collects triangles that share the same material, grouped by transparency
+ * level. Each MeshGroup becomes a separate glTF mesh with its own material.
+ */
+struct MeshGroup {
+  float transparency = 0.0f;
+  std::vector<float> positions; /* x,y,z per vertex */
+  std::vector<float> normals;   /* x,y,z per vertex */
+  std::vector<float> colors;    /* r,g,b per vertex */
+  std::vector<std::uint32_t> indices;
+  std::uint32_t vertex_count = 0;
+
+  /* bounding box for POSITION accessor */
+  float min_pos[3] = {std::numeric_limits<float>::max(),
+      std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
+  float max_pos[3] = {std::numeric_limits<float>::lowest(),
+      std::numeric_limits<float>::lowest(),
+      std::numeric_limits<float>::lowest()};
+
+  /**
+   * Append a vertex with position, normal, and color, updating the bounding
+   * box.
+   * @param pos xyz position (3 floats)
+   * @param norm xyz normal (3 floats)
+   * @param col rgb color (3 floats, 0-1 range)
+   */
+  void addVertex(const float* pos, const float* norm, const float* col)
+  {
+    positions.push_back(pos[0]);
+    positions.push_back(pos[1]);
+    positions.push_back(pos[2]);
+    normals.push_back(norm[0]);
+    normals.push_back(norm[1]);
+    normals.push_back(norm[2]);
+    colors.push_back(col[0]);
+    colors.push_back(col[1]);
+    colors.push_back(col[2]);
+
+    for (int i = 0; i < 3; i++) {
+      if (pos[i] < min_pos[i])
+        min_pos[i] = pos[i];
+      if (pos[i] > max_pos[i])
+        max_pos[i] = pos[i];
+    }
+    vertex_count++;
+  }
+
+  /**
+   * Append a triangle defined by three vertex indices.
+   * @param i0 first vertex index
+   * @param i1 second vertex index
+   * @param i2 third vertex index
+   */
+  void addTriangle(std::uint32_t i0, std::uint32_t i1, std::uint32_t i2)
+  {
+    indices.push_back(i0);
+    indices.push_back(i1);
+    indices.push_back(i2);
+  }
+
+  bool empty() const { return indices.empty(); }
+};
+
+/**
+ * Find or create a MeshGroup for the given transparency level. Groups are
+ * matched with TRANS_PRECISION tolerance so nearly-identical transparencies
+ * share a single glTF material.
+ * @param groups vector of existing mesh groups
+ * @param trans transparency value (0 = opaque, 1 = fully transparent)
+ * @return reference to the matching or newly created group
+ */
+static MeshGroup& findOrCreateGroup(std::vector<MeshGroup>& groups, float trans)
+{
+  for (auto& g : groups) {
+    if (fabsf(g.transparency - trans) < TRANS_PRECISION)
+      return g;
+  }
+  groups.emplace_back();
+  groups.back().transparency = trans;
+  return groups.back();
+}
+
+/**
+ * Tessellate a sphere primitive into triangles using the pre-computed
+ * SphereRec mesh at the current sphere_quality setting.
+ * @param group mesh group to append geometry to
+ * @param prim sphere primitive (uses v1 for center, r1 for radius, c1 for
+ *   color)
+ * @param G global context (for sphere_quality setting and SphereRec lookup)
+ */
+static void addSphere(MeshGroup& group, const CPrimitive* prim, PyMOLGlobals* G)
+{
+  int sq = SettingGetGlobal_i(G, cSetting_sphere_quality);
+  SphereRec* sp = G->Sphere->Sphere[sq];
+
+  /* Use the pre-computed triangle mesh (Tri array) for spheres.
+   * sp->Tri contains triangle indices into sp->dot[] */
+  std::uint32_t base = group.vertex_count;
+
+  /* Add all sphere vertices */
+  for (int i = 0; i < sp->nDot; i++) {
+    float pos[3] = {prim->v1[0] + prim->r1 * sp->dot[i][0],
+        prim->v1[1] + prim->r1 * sp->dot[i][1],
+        prim->v1[2] + prim->r1 * sp->dot[i][2]};
+    float norm[3] = {sp->dot[i][0], sp->dot[i][1], sp->dot[i][2]};
+    group.addVertex(pos, norm, prim->c1);
+  }
+
+  /* Add triangles */
+  for (int i = 0; i < sp->NTri; i++) {
+    int i0 = sp->Tri[i * 3 + 0];
+    int i1 = sp->Tri[i * 3 + 1];
+    int i2 = sp->Tri[i * 3 + 2];
+    group.addTriangle(base + i0, base + i1, base + i2);
+  }
+}
+
+#define GLB_MAX_EDGE 50
+#define CONE_MIN_RADIUS 10e-6f // Adopted from COLLADA.cpp
+
+/**
+ * Convert a CGO round nub cap (emitted as a triangle strip) into indexed
+ * triangles and append them to a mesh group.
+ * @param group mesh group to append geometry to
+ * @param cgo CGO containing the cap geometry (CGO_BEGIN/NORMAL/VERTEX ops)
+ * @param cap_color rgb color for all cap vertices (3 floats)
+ * @note The CGO is expected to contain a single triangle strip. Winding
+ *   order alternates per the GL_TRIANGLE_STRIP convention.
+ */
+static void addCylinderCGOCap(
+    MeshGroup& group, CGO* cgo, const float* cap_color)
+{
+  if (!cgo)
+    return;
+
+  int strip_vert_count = 0;
+  float cur_normal[3] = {0, 0, 0};
+
+  for (auto it = cgo->begin(); !it.is_stop(); ++it) {
+    auto pc = it.data();
+    int op = it.op_code();
+    switch (op) {
+    case CGO_BEGIN:
+      strip_vert_count = 0;
+      break;
+    case CGO_NORMAL:
+      cur_normal[0] = pc[0];
+      cur_normal[1] = pc[1];
+      cur_normal[2] = pc[2];
+      break;
+    case CGO_VERTEX: {
+      float pos[3] = {pc[0], pc[1], pc[2]};
+      group.addVertex(pos, cur_normal, cap_color);
+      strip_vert_count++;
+
+      if (strip_vert_count >= 3) {
+        std::uint32_t cur = group.vertex_count - 1;
+        if (strip_vert_count % 2 == 1) {
+          group.addTriangle(cur - 2, cur - 1, cur);
+        } else {
+          group.addTriangle(cur - 1, cur - 2, cur);
+        }
+      }
+      break;
+    }
+    }
+  }
+}
+
+/**
+ * Tessellate a cylinder, sausage, or cone primitive into triangles. Generates
+ * the shaft as a ring of quads, plus flat or round caps at each end depending
+ * on the primitive's cap types and the stick_round_nub setting.
+ * @param group mesh group to append geometry to
+ * @param prim cylinder/sausage/cone primitive (uses v1/v2 for endpoints,
+ *   r1/r2 for radii, c1/c2 for endpoint colors, cap1/cap2 for cap types)
+ * @param G global context (for stick_quality, stick_overlap, stick_nub,
+ *   stick_round_nub settings)
+ * @note Sausage primitives force round caps on both ends. Cone primitives
+ *   allow different radii (r1, r2) at each endpoint.
+ */
+static void addCylinderWithCaps(
+    MeshGroup& group, const CPrimitive* prim, PyMOLGlobals* G)
+{
+  float d[3], t[3], p0[3], p1[3], p2[3];
+  float vv1[3], vv2[3], vvv1[3], vvv2[3];
+  float x[GLB_MAX_EDGE + 1], y[GLB_MAX_EDGE + 1];
+  float overlap, overlap2, nub, nub2, r2;
+
+  int nEdge = SettingGetGlobal_i(G, cSetting_stick_quality);
+  bool stick_round_nub = SettingGetGlobal_i(G, cSetting_stick_round_nub);
+
+  cCylCap captype[2] = {prim->cap1, prim->cap2};
+  std::unique_ptr<CGO> cgocap[2];
+
+  if (prim->type == cPrimSausage) {
+    captype[0] = captype[1] = cCylCapRound;
+  }
+
+  overlap = prim->r1 * SettingGetGlobal_f(G, cSetting_stick_overlap);
+  nub = prim->r1 * SettingGetGlobal_f(G, cSetting_stick_nub);
+  if (prim->type == cPrimCone) {
+    r2 = prim->r2;
+    overlap2 = prim->r2 * SettingGetGlobal_f(G, cSetting_stick_overlap);
+    nub2 = prim->r2 * SettingGetGlobal_f(G, cSetting_stick_nub);
+  } else {
+    r2 = prim->r1;
+    overlap2 = overlap;
+    nub2 = nub;
+  }
+
+  if (nEdge > GLB_MAX_EDGE)
+    nEdge = GLB_MAX_EDGE;
+  subdivide(nEdge, x, y);
+
+  p0[0] = prim->v2[0] - prim->v1[0];
+  p0[1] = prim->v2[1] - prim->v1[1];
+  p0[2] = prim->v2[2] - prim->v1[2];
+  normalize3f(p0);
+
+  copy3f(prim->v1, vv1);
+  copy3f(vv1, vvv1);
+  copy3f(prim->v2, vv2);
+  copy3f(vv2, vvv2);
+
+  d[0] = vv2[0] - vv1[0];
+  d[1] = vv2[1] - vv1[1];
+  d[2] = vv2[2] - vv1[2];
+  get_divergent3f(d, t);
+  cross_product3f(d, t, p1);
+  normalize3f(p1);
+  cross_product3f(d, p1, p2);
+  normalize3f(p2);
+
+  if (captype[0] == cCylCapRound) {
+    if (stick_round_nub) {
+      cgocap[0].reset(CGONew(G));
+      CGORoundNub(cgocap[0].get(), prim->v1, p0, p1, p2, -1, nEdge, prim->r1);
+    } else {
+      for (int i = 0; i < 3; i++) {
+        vv1[i] -= p0[i] * overlap;
+        vvv1[i] = vv1[i] - p0[i] * nub;
+      }
+    }
+  }
+  if (captype[1] == cCylCapRound) {
+    if (stick_round_nub) {
+      cgocap[1].reset(CGONew(G));
+      CGORoundNub(cgocap[1].get(), prim->v2, p0, p1, p2, 1, nEdge, prim->r1);
+    } else {
+      for (int i = 0; i < 3; i++) {
+        vv2[i] += p0[i] * overlap2;
+        vvv2[i] = vv2[i] + p0[i] * nub2;
+      }
+    }
+  }
+
+  /* Shaft */
+  std::uint32_t base = group.vertex_count;
+
+  for (int c = nEdge; c >= 0; c--) {
+    float v[3];
+    v[0] = p1[0] * x[c] + p2[0] * y[c];
+    v[1] = p1[1] * x[c] + p2[1] * y[c];
+    v[2] = p1[2] * x[c] + p2[2] * y[c];
+
+    float bot[3] = {vv1[0] + v[0] * prim->r1, vv1[1] + v[1] * prim->r1,
+        vv1[2] + v[2] * prim->r1};
+    float top[3] = {vv2[0] + v[0] * r2, vv2[1] + v[1] * r2, vv2[2] + v[2] * r2};
+    float norm[3] = {v[0], v[1], v[2]};
+
+    group.addVertex(bot, norm, prim->c1);
+    group.addVertex(top, norm, prim->c2);
+  }
+
+  for (int c = 0; c < nEdge; c++) {
+    std::uint32_t bl = base + c * 2;
+    std::uint32_t tl = base + c * 2 + 1;
+    std::uint32_t br = base + (c + 1) * 2;
+    std::uint32_t tr = base + (c + 1) * 2 + 1;
+    group.addTriangle(bl, br, tl);
+    group.addTriangle(tl, br, tr);
+  }
+
+  /* Flat caps */
+  if (prim->r1 > CONE_MIN_RADIUS && !cgocap[0] && captype[0] != cCylCapNone) {
+    float neg_p0[3] = {-p0[0], -p0[1], -p0[2]};
+    std::uint32_t center_idx = group.vertex_count;
+    group.addVertex(vvv1, neg_p0, prim->c1);
+    for (int i = 0; i < nEdge; i++) {
+      group.addTriangle(center_idx, base + i * 2, base + (i + 1) * 2);
+    }
+  }
+
+  if (r2 > CONE_MIN_RADIUS && !cgocap[1] && captype[1] != cCylCapNone) {
+    std::uint32_t center_idx = group.vertex_count;
+    group.addVertex(vvv2, p0, prim->c2);
+    for (int i = 0; i < nEdge; i++) {
+      group.addTriangle(center_idx, base + (i + 1) * 2 + 1, base + i * 2 + 1);
+    }
+  }
+
+  /* CGO round caps */
+  for (int capIdx = 0; capIdx < 2; capIdx++) {
+    if (cgocap[capIdx]) {
+      const float* cap_color = (capIdx == 0) ? prim->c1 : prim->c2;
+      addCylinderCGOCap(group, cgocap[capIdx].get(), cap_color);
+    }
+  }
+}
+
+/**
+ * Add a triangle primitive's three vertices and one triangle index.
+ * @param group mesh group to append geometry to
+ * @param prim triangle primitive (uses v1-v3, n1-n3, c1-c3)
+ * @note Winding order is flipped when TriangleReverse() returns true.
+ */
+static void addTriangle(MeshGroup& group, const CPrimitive* prim)
+{
+  std::uint32_t base = group.vertex_count;
+
+  group.addVertex(prim->v1, prim->n1, prim->c1);
+  group.addVertex(prim->v2, prim->n2, prim->c2);
+  group.addVertex(prim->v3, prim->n3, prim->c3);
+
+  if (TriangleReverse(const_cast<CPrimitive*>(prim))) {
+    group.addTriangle(base, base + 2, base + 1);
+  } else {
+    group.addTriangle(base, base + 1, base + 2);
+  }
+}
+
+/**
+ * Round a size up to the next multiple of 4.
+ * @param size byte count to align
+ * @return size rounded up to 4-byte boundary
+ * @note Required by the GLB spec for chunk alignment.
+ */
+static std::uint32_t alignTo4(std::uint32_t size)
+{
+  return (size + 3) & ~3u;
+}
+
+/**
+ * Write a uint32 in little-endian byte order to a byte vector.
+ * @param[out] out byte vector to append to
+ * @param val 32-bit value to write
+ */
+static void writeU32(std::vector<std::uint8_t>& out, std::uint32_t val)
+{
+  out.push_back(val & 0xFF);
+  out.push_back((val >> 8) & 0xFF);
+  out.push_back((val >> 16) & 0xFF);
+  out.push_back((val >> 24) & 0xFF);
+}
+
+/**
+ * Append floats to a byte vector in little-endian byte order.
+ * @param[out] out byte vector to append to
+ * @param data source float data
+ */
+static void appendFloats(
+    std::vector<std::uint8_t>& out, const std::vector<float>& data)
+{
+  for (float f : data) {
+    std::uint32_t bits;
+    std::memcpy(&bits, &f, sizeof(float));
+    writeU32(out, bits);
+  }
+}
+
+/**
+ * Append uint32s to a byte vector in little-endian byte order.
+ * @param[out] out byte vector to append to
+ * @param data source uint32 data
+ */
+static void appendU32s(
+    std::vector<std::uint8_t>& out, const std::vector<std::uint32_t>& data)
+{
+  for (std::uint32_t v : data) {
+    writeU32(out, v);
+  }
+}
+
+/**
+ * Byte offset and length of a single attribute's data within the binary
+ * buffer. Corresponds to one glTF bufferView.
+ */
+struct BufferViewInfo {
+  std::uint32_t offset;
+  std::uint32_t length;
+};
+
+/**
+ * Buffer layout info for one MeshGroup (positions, normals, colors, indices).
+ */
+struct GroupBufferInfo {
+  BufferViewInfo positions;
+  BufferViewInfo normals;
+  BufferViewInfo colors;
+  BufferViewInfo indices;
+};
+
+/**
+ * Pack all mesh groups' vertex attributes and indices into a single contiguous
+ * binary buffer suitable for the GLB BIN chunk.
+ *
+ * Layout per group: [positions][normals][colors][indices]
+ *
+ * @param groups mesh groups containing vertex/index data
+ * @param[out] infos byte offset and length for each group's attributes
+ * @return the packed binary buffer
+ * @note All sections are naturally 4-byte aligned (float and uint32 data).
+ */
+static std::vector<std::uint8_t> buildBinaryBuffer(
+    const std::vector<MeshGroup>& groups, std::vector<GroupBufferInfo>& infos)
+{
+  std::vector<std::uint8_t> buffer;
+  infos.resize(groups.size());
+
+  for (size_t g = 0; g < groups.size(); g++) {
+    const auto& mesh = groups[g];
+    auto& info = infos[g];
+
+    /* Positions */
+    info.positions.offset = static_cast<std::uint32_t>(buffer.size());
+    info.positions.length =
+        static_cast<std::uint32_t>(mesh.positions.size() * sizeof(float));
+    appendFloats(buffer, mesh.positions);
+
+    /* Normals */
+    info.normals.offset = static_cast<std::uint32_t>(buffer.size());
+    info.normals.length =
+        static_cast<std::uint32_t>(mesh.normals.size() * sizeof(float));
+    appendFloats(buffer, mesh.normals);
+
+    /* Colors */
+    info.colors.offset = static_cast<std::uint32_t>(buffer.size());
+    info.colors.length =
+        static_cast<std::uint32_t>(mesh.colors.size() * sizeof(float));
+    appendFloats(buffer, mesh.colors);
+
+    /* Indices */
+    info.indices.offset = static_cast<std::uint32_t>(buffer.size());
+    info.indices.length =
+        static_cast<std::uint32_t>(mesh.indices.size() * sizeof(std::uint32_t));
+    appendU32s(buffer, mesh.indices);
+  }
+
+  return buffer;
+}
+
+/**
+ * Build the glTF 2.0 JSON descriptor for the scene. Creates one mesh, node,
+ * and PBR material per MeshGroup, with POSITION/NORMAL/COLOR_0 vertex
+ * attributes and UNSIGNED_INT indices.
+ * @param groups mesh groups (one per transparency level)
+ * @param infos buffer layout info from buildBinaryBuffer()
+ * @param buffer_size total size of the binary buffer in bytes
+ * @return serialized JSON string
+ */
+static std::string buildGLTFJson(const std::vector<MeshGroup>& groups,
+    const std::vector<GroupBufferInfo>& infos, std::uint32_t buffer_size)
+{
+  json root;
+
+  /* Asset */
+  root["asset"] = {
+      {"version", "2.0"},
+#ifdef _PyMOL_VERSION
+      {"generator", "PyMOL " _PyMOL_VERSION},
+#else
+      {"generator", "PyMOL"},
+#endif
+  };
+
+  /* Scene */
+  root["scene"] = 0;
+
+  /* Build arrays */
+  json nodes = json::array();
+  json meshes = json::array();
+  json materials = json::array();
+  json accessors = json::array();
+  json buffer_views = json::array();
+
+  int accessor_idx = 0;
+  int buffer_view_idx = 0;
+
+  for (size_t g = 0; g < groups.size(); g++) {
+    const auto& mesh = groups[g];
+    const auto& info = infos[g];
+
+    if (mesh.empty())
+      continue;
+
+    int mat_idx = static_cast<int>(materials.size());
+
+    /* Material */
+    json mat;
+    json pbr;
+    pbr["baseColorFactor"] = {1.0, 1.0, 1.0, 1.0 - mesh.transparency};
+    pbr["metallicFactor"] = 0.0;
+    pbr["roughnessFactor"] = 0.7;
+    mat["pbrMetallicRoughness"] = pbr;
+
+    if (mesh.transparency > TRANS_PRECISION) {
+      mat["alphaMode"] = "BLEND";
+    } else {
+      mat["alphaMode"] = "OPAQUE";
+    }
+    mat["doubleSided"] = false;
+    materials.push_back(mat);
+
+    /* Buffer views: positions */
+    int bv_pos = buffer_view_idx++;
+    buffer_views.push_back({
+        {"buffer", 0},
+        {"byteOffset", info.positions.offset},
+        {"byteLength", info.positions.length},
+        {"target", 34962}, /* ARRAY_BUFFER */
+    });
+
+    /* Buffer views: normals */
+    int bv_norm = buffer_view_idx++;
+    buffer_views.push_back({
+        {"buffer", 0},
+        {"byteOffset", info.normals.offset},
+        {"byteLength", info.normals.length},
+        {"target", 34962},
+    });
+
+    /* Buffer views: colors */
+    int bv_col = buffer_view_idx++;
+    buffer_views.push_back({
+        {"buffer", 0},
+        {"byteOffset", info.colors.offset},
+        {"byteLength", info.colors.length},
+        {"target", 34962},
+    });
+
+    /* Buffer views: indices */
+    int bv_idx = buffer_view_idx++;
+    buffer_views.push_back({
+        {"buffer", 0},
+        {"byteOffset", info.indices.offset},
+        {"byteLength", info.indices.length},
+        {"target", 34963}, /* ELEMENT_ARRAY_BUFFER */
+    });
+
+    /* Accessor: positions */
+    int acc_pos = accessor_idx++;
+    accessors.push_back({
+        {"bufferView", bv_pos},
+        {"componentType", 5126}, /* FLOAT */
+        {"count", mesh.vertex_count},
+        {"type", "VEC3"},
+        {"min", {mesh.min_pos[0], mesh.min_pos[1], mesh.min_pos[2]}},
+        {"max", {mesh.max_pos[0], mesh.max_pos[1], mesh.max_pos[2]}},
+    });
+
+    /* Accessor: normals */
+    int acc_norm = accessor_idx++;
+    accessors.push_back({
+        {"bufferView", bv_norm},
+        {"componentType", 5126},
+        {"count", mesh.vertex_count},
+        {"type", "VEC3"},
+    });
+
+    /* Accessor: colors */
+    int acc_col = accessor_idx++;
+    accessors.push_back({
+        {"bufferView", bv_col},
+        {"componentType", 5126},
+        {"count", mesh.vertex_count},
+        {"type", "VEC3"},
+    });
+
+    /* Accessor: indices */
+    int acc_idx = accessor_idx++;
+    std::uint32_t max_index =
+        *std::max_element(mesh.indices.begin(), mesh.indices.end());
+    accessors.push_back({
+        {"bufferView", bv_idx},
+        {"componentType", 5125}, /* UNSIGNED_INT */
+        {"count", mesh.indices.size()},
+        {"type", "SCALAR"},
+        {"min", {0}},
+        {"max", {max_index}},
+    });
+
+    /* Mesh */
+    json primitive;
+    primitive["attributes"] = {
+        {"POSITION", acc_pos},
+        {"NORMAL", acc_norm},
+        {"COLOR_0", acc_col},
+    };
+    primitive["indices"] = acc_idx;
+    primitive["material"] = mat_idx;
+    primitive["mode"] = 4; /* TRIANGLES */
+
+    json mesh_obj;
+    mesh_obj["primitives"] = json::array({primitive});
+    int mesh_idx = static_cast<int>(meshes.size());
+    meshes.push_back(mesh_obj);
+
+    /* Node */
+    nodes.push_back({{"mesh", mesh_idx}});
+  }
+
+  /* Scene: reference all nodes */
+  json scene;
+  json children = json::array();
+  for (size_t i = 0; i < nodes.size(); i++) {
+    children.push_back(static_cast<int>(i));
+  }
+  scene["nodes"] = children;
+  root["scenes"] = json::array({scene});
+
+  root["nodes"] = nodes;
+  root["meshes"] = meshes;
+  root["materials"] = materials;
+  root["accessors"] = accessors;
+  root["bufferViews"] = buffer_views;
+
+  /* Buffer */
+  root["buffers"] = json::array({{{"byteLength", buffer_size}}});
+
+  return root.dump();
+}
+
+void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
+    float back, float fov)
+{
+  PyMOLGlobals* G = I->G;
+
+  int identity = (SettingGetGlobal_i(G, cSetting_geometry_export_mode) == 1);
+
+  /* Ray trace - expand all objects into primitives */
+  RayExpandPrimitives(I);
+  RayTransformFirst(I, 0, identity);
+
+  /* Collect primitives into mesh groups by transparency */
+  std::vector<MeshGroup> groups;
+
+  for (int a = 0; a < I->NPrimitive; a++) {
+    CPrimitive* prim = I->Primitive + a;
+
+    MeshGroup& group = findOrCreateGroup(groups, prim->trans);
+
+    switch (prim->type) {
+    case cPrimTriangle:
+      addTriangle(group, prim);
+      break;
+
+    case cPrimSphere:
+      addSphere(group, prim, G);
+      break;
+
+    case cPrimCylinder:
+    case cPrimSausage:
+    case cPrimCone:
+      addCylinderWithCaps(group, prim, G);
+      break;
+
+    case cPrimCharacter:
+    case cPrimEllipsoid:
+      /* Not supported - skip silently (same as COLLADA) */
+      break;
+    }
+  }
+
+  /* Remove empty groups */
+  groups.erase(std::remove_if(groups.begin(), groups.end(),
+                   [](const MeshGroup& g) { return g.empty(); }),
+      groups.end());
+
+  if (groups.empty()) {
+    PRINTFB(G, FB_Ray, FB_Warnings)
+    " GLB-Warning: No geometry to export.\n" ENDFB(G);
+    VLASize(*vla_ptr, char, 0);
+    return;
+  }
+
+  /* Build binary buffer */
+  std::vector<GroupBufferInfo> buffer_infos;
+  auto bin_buffer = buildBinaryBuffer(groups, buffer_infos);
+
+  /* Build JSON */
+  std::string json_str = buildGLTFJson(
+      groups, buffer_infos, static_cast<std::uint32_t>(bin_buffer.size()));
+
+  /* Pad JSON to 4-byte alignment with spaces */
+  std::uint32_t json_len = static_cast<std::uint32_t>(json_str.size());
+  std::uint32_t json_padded = alignTo4(json_len);
+  json_str.resize(json_padded, ' ');
+
+  /* Pad binary buffer to 4-byte alignment with zeros */
+  std::uint32_t bin_len = static_cast<std::uint32_t>(bin_buffer.size());
+  std::uint32_t bin_padded = alignTo4(bin_len);
+  bin_buffer.resize(bin_padded, 0);
+
+  /* Assemble GLB */
+  std::uint32_t total_size = GLB_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE +
+                             json_padded + GLB_CHUNK_HEADER_SIZE + bin_padded;
+
+  std::vector<std::uint8_t> glb;
+  glb.reserve(total_size);
+
+  /* Header */
+  writeU32(glb, GLB_MAGIC);
+  writeU32(glb, GLB_VERSION);
+  writeU32(glb, total_size);
+
+  /* JSON chunk */
+  writeU32(glb, json_padded);
+  writeU32(glb, GLB_CHUNK_JSON);
+  glb.insert(glb.end(), json_str.begin(), json_str.end());
+
+  /* BIN chunk */
+  writeU32(glb, bin_padded);
+  writeU32(glb, GLB_CHUNK_BIN);
+  glb.insert(glb.end(), bin_buffer.begin(), bin_buffer.end());
+
+  /* Copy to VLA output */
+  char* vla = *vla_ptr;
+
+  VLACheck(vla, char, total_size);
+  if (!vla) {
+    PRINTFB(G, FB_Ray, FB_Errors)
+    " GLB-Error: Failed to allocate output buffer.\n" ENDFB(G);
+    *vla_ptr = nullptr;
+    return;
+  }
+  memcpy(vla, glb.data(), total_size);
+  VLASize(vla, char, total_size);
+
+  *vla_ptr = vla;
+
+  PRINTFB(G, FB_Ray, FB_Actions)
+  " GLB: exported %d mesh group(s), %u bytes total.\n", (int) groups.size(),
+      total_size ENDFB(G);
+}

--- a/layer1/GLTF.h
+++ b/layer1/GLTF.h
@@ -19,10 +19,13 @@
  * @param width scene width (unused, reserved for future use)
  * @param height scene height (unused, reserved for future use)
  * @param[in,out] vla_ptr pre-allocated VLA; on return, resized to hold the
- *   GLB binary data (or resized to 0 if no geometry) -- little endian
+ *   GLB binary data (little endian), or resized to 0 if the scene has no
+ *   exportable geometry or does not fit the 32-bit GLB container limit
  * @param front camera front plane (unused, reserved for future use)
  * @param back camera back plane (unused, reserved for future use)
  * @param fov camera field of view (unused, reserved for future use)
+ * @note Text label and ellipsoid primitives are not supported yet, they are
+ *   skipped with a warning.
  */
 void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
     float back, float fov);

--- a/layer1/GLTF.h
+++ b/layer1/GLTF.h
@@ -8,6 +8,8 @@
 
 #include "Base.h"
 
+#ifdef _HAVE_JSON
+
 /**
  * Render the current scene as a GLB (binary glTF 2.0) file. Expands all
  * objects into ray-tracing primitives, tessellates spheres/cylinders/cones
@@ -24,3 +26,5 @@
  */
 void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
     float back, float fov);
+
+#endif

--- a/layer1/GLTF.h
+++ b/layer1/GLTF.h
@@ -1,0 +1,26 @@
+/*
+ * PyMOL glTF 2.0 / GLB export
+ *
+ * (c) 2026 Schrodinger, Inc.
+ */
+
+#pragma once
+
+#include "Base.h"
+
+/**
+ * Render the current scene as a GLB (binary glTF 2.0) file. Expands all
+ * objects into ray-tracing primitives, tessellates spheres/cylinders/cones
+ * into triangle meshes, groups by transparency, and writes the GLB container
+ * (header + JSON chunk + BIN chunk) into the output VLA.
+ * @param I ray context with primitive data
+ * @param width scene width (unused, reserved for future use)
+ * @param height scene height (unused, reserved for future use)
+ * @param[in,out] vla_ptr pre-allocated VLA; on return, resized to hold the
+ *   GLB binary data (or resized to 0 if no geometry) -- little endian
+ * @param front camera front plane (unused, reserved for future use)
+ * @param back camera back plane (unused, reserved for future use)
+ * @param fov camera field of view (unused, reserved for future use)
+ */
+void RayRenderGLB(CRay* I, int width, int height, char** vla_ptr, float front,
+    float back, float fov);

--- a/layer1/Ray.h
+++ b/layer1/Ray.h
@@ -60,6 +60,8 @@ void RayRenderVRML2(CRay * I, int width, int height,
                     float fov, float angle, float z_corr);
 void RayRenderCOLLADA(CRay * I, int width, int height,
                     char **vla_ptr, float front, float back, float fov);
+void RayRenderGLB(CRay * I, int width, int height,
+                    char **vla_ptr, float front, float back, float fov);
 void RayRenderObjMtl(CRay * I, int width, int height, char **objVLA_ptr,
                      char **mtlVLA_ptr, float front, float back, float fov,
                      float angle, float z_corr);

--- a/layer1/Ray.h
+++ b/layer1/Ray.h
@@ -60,10 +60,6 @@ void RayRenderVRML2(CRay * I, int width, int height,
                     float fov, float angle, float z_corr);
 void RayRenderCOLLADA(CRay * I, int width, int height,
                     char **vla_ptr, float front, float back, float fov);
-#ifdef _HAVE_JSON
-void RayRenderGLB(CRay * I, int width, int height,
-                    char **vla_ptr, float front, float back, float fov);
-#endif
 void RayRenderObjMtl(CRay * I, int width, int height, char **objVLA_ptr,
                      char **mtlVLA_ptr, float front, float back, float fov,
                      float angle, float z_corr);

--- a/layer1/Ray.h
+++ b/layer1/Ray.h
@@ -60,8 +60,10 @@ void RayRenderVRML2(CRay * I, int width, int height,
                     float fov, float angle, float z_corr);
 void RayRenderCOLLADA(CRay * I, int width, int height,
                     char **vla_ptr, float front, float back, float fov);
+#ifdef _HAVE_JSON
 void RayRenderGLB(CRay * I, int width, int height,
                     char **vla_ptr, float front, float back, float fov);
+#endif
 void RayRenderObjMtl(CRay * I, int width, int height, char **objVLA_ptr,
                      char **mtlVLA_ptr, float front, float back, float fov,
                      float angle, float z_corr);

--- a/layer1/Scene.h
+++ b/layer1/Scene.h
@@ -37,6 +37,7 @@ Z* -------------------------------------------------------------------
 
 // TODO: define remaining cSceneRay_MODEs (VRML, COLLADA, etc.)
 #define cSceneRay_MODE_IDTF 7
+#define cSceneRay_MODE_GLB 9
 
 #define cSceneImage_Default -1
 #define cSceneImage_Normal 0
@@ -411,4 +412,3 @@ pymol::Image GLImageToPyMOLImage(
     PyMOLGlobals* G, const GLFramebufferConfig& config, const Rect2D& srcRect);
 
 #endif
-

--- a/layer1/SceneRay.cpp
+++ b/layer1/SceneRay.cpp
@@ -488,6 +488,7 @@ bool SceneRay(PyMOLGlobals * G,
         }
         break;
 
+#ifdef _HAVE_JSON
       case cSceneRay_MODE_GLB:  /* mode 9 is GLB (glTF 2.0 binary) */
         {
           *charVLA_ptr = VLACalloc(char, 100000);
@@ -495,6 +496,7 @@ bool SceneRay(PyMOLGlobals * G,
                         I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back, fov);
         }
         break;
+#endif
 
       }
       RayFree(ray);

--- a/layer1/SceneRay.cpp
+++ b/layer1/SceneRay.cpp
@@ -10,6 +10,7 @@
 #include"Color.h"
 #include"P.h"
 #include "Feedback.h"
+#include "GLTF.h"
 
 static double accumTiming = 0.0;
 

--- a/layer1/SceneRay.cpp
+++ b/layer1/SceneRay.cpp
@@ -488,6 +488,14 @@ bool SceneRay(PyMOLGlobals * G,
         }
         break;
 
+      case cSceneRay_MODE_GLB:  /* mode 9 is GLB (glTF 2.0 binary) */
+        {
+          *charVLA_ptr = VLACalloc(char, 100000);
+          RayRenderGLB(ray, ray_width, ray_height, charVLA_ptr,
+                        I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back, fov);
+        }
+        break;
+
       }
       RayFree(ray);
     }

--- a/layer1/SceneRay.cpp
+++ b/layer1/SceneRay.cpp
@@ -494,7 +494,8 @@ bool SceneRay(PyMOLGlobals * G,
         {
           *charVLA_ptr = VLACalloc(char, 100000);
           RayRenderGLB(ray, ray_width, ray_height, charVLA_ptr,
-                        I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back, fov);
+              I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back,
+              fov);
         }
         break;
 #endif

--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -2719,6 +2719,35 @@ static PyObject *CmdGetCOLLADA(PyObject * self, PyObject * args)
 }
 
 
+/**
+ * Return a GLB (binary glTF 2.0) bytes object or None on failure
+ */
+static PyObject *CmdGetGLB(PyObject * self, PyObject * args)
+{
+  PyMOLGlobals *G = nullptr;
+  PyObject *result = nullptr;
+  char *vla = nullptr;
+
+  API_SETUP_ARGS(G, self, args, "O", &self);
+  API_ASSERT(APIEnterNotModal(G));
+
+  SceneRay(G, 0, 0, cSceneRay_MODE_GLB,
+      nullptr, &vla, 0.0F, 0.0F, false, nullptr, false, -1);
+  APIExit(G);
+
+  if (vla) {
+    ov_size vla_size = VLAGetSize(vla);
+    if (vla_size > 0) {
+      result = Py_BuildValue("y#", vla, (Py_ssize_t)vla_size);
+    }
+  }
+
+  VLAFreeP(vla);
+
+  return APIAutoNone(result);
+}
+
+
 static PyObject *CmdGetIdtf(PyObject * self, PyObject * args)
 {
   PyMOLGlobals *G = nullptr;
@@ -6452,6 +6481,7 @@ static PyMethodDef Cmd_methods[] = {
   {"get_clip", CmdGetClip, METH_VARARGS},
   {"get_collada", CmdGetCOLLADA, METH_VARARGS},
   {"get_color", CmdGetColor, METH_VARARGS},
+  {"get_glb", CmdGetGLB, METH_VARARGS},
   {"get_colorection", CmdGetColorection, METH_VARARGS},
   {"get_coords", CmdGetCoordsAsNumPy, METH_VARARGS},
   {"get_coordset", CmdGetCoordSetAsNumPy, METH_VARARGS},

--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -1682,6 +1682,10 @@ static PyObject* CmdGetCapabilities(PyObject*, PyObject*)
     // COLLADA export
     PySet_Add(caps, PConvToPyObject("collada"));
 #endif
+#ifdef _HAVE_JSON
+    // native glTF 2.0 and GLB export
+    PySet_Add(caps, PConvToPyObject("gltf"));
+#endif
 #ifdef _PYMOL_CTEST
     // compiled with --testing
     PySet_Add(caps, PConvToPyObject("testing"));
@@ -2719,6 +2723,7 @@ static PyObject *CmdGetCOLLADA(PyObject * self, PyObject * args)
 }
 
 
+#ifdef _HAVE_JSON
 /**
  * Return a GLB (binary glTF 2.0) bytes object or None on failure
  */
@@ -2746,6 +2751,7 @@ static PyObject *CmdGetGLB(PyObject * self, PyObject * args)
 
   return APIAutoNone(result);
 }
+#endif // _HAVE_JSON
 
 
 static PyObject *CmdGetIdtf(PyObject * self, PyObject * args)
@@ -6481,7 +6487,9 @@ static PyMethodDef Cmd_methods[] = {
   {"get_clip", CmdGetClip, METH_VARARGS},
   {"get_collada", CmdGetCOLLADA, METH_VARARGS},
   {"get_color", CmdGetColor, METH_VARARGS},
+#ifdef _HAVE_JSON
   {"get_glb", CmdGetGLB, METH_VARARGS},
+#endif
   {"get_colorection", CmdGetColorection, METH_VARARGS},
   {"get_coords", CmdGetCoordsAsNumPy, METH_VARARGS},
   {"get_coordset", CmdGetCoordSetAsNumPy, METH_VARARGS},

--- a/modules/pmg_qt/pymol_qt_gui.py
+++ b/modules/pmg_qt/pymol_qt_gui.py
@@ -817,6 +817,9 @@ PyMOL> color ye<TAB>    (will autocomplete "yellow")
     def file_save_stl(self):
         self._file_save('STL File (*.stl)', 'stl')
 
+    def file_save_glb(self):
+        self._file_save('GLB File (*.glb)', 'glb')
+
     def file_save_gltf(self):
         self._file_save('GLTF File (*.gltf)', 'gltf')
 

--- a/modules/pymol/_gui.py
+++ b/modules/pymol/_gui.py
@@ -24,6 +24,7 @@ class PyMOLDesktopGUI(object):
     file_save_mpeg = None
     file_save_mov = None
     file_save_mpng = None
+    file_save_glb = None
     file_save_gltf = None
     file_save_stl = None
     log_open = None
@@ -98,6 +99,7 @@ class PyMOLDesktopGUI(object):
                     ('separator',),
                     ('command', 'VRML 2...',        self.file_save_wrl),
                     ('command', 'COLLADA...',       self.file_save_dae),
+                    ('command', 'GLB...',            self.file_save_glb),
                     ('command', 'GLTF...',          self.file_save_gltf),
                     ('command', 'POV-Ray...',       self.file_save_pov),
                     ('command', 'STL...',           self.file_save_stl),

--- a/modules/pymol/_gui.py
+++ b/modules/pymol/_gui.py
@@ -99,7 +99,7 @@ class PyMOLDesktopGUI(object):
                     ('separator',),
                     ('command', 'VRML 2...',        self.file_save_wrl),
                     ('command', 'COLLADA...',       self.file_save_dae),
-                    ('command', 'GLB...',            self.file_save_glb),
+                    ('command', 'GLB...',           self.file_save_glb),
                     ('command', 'GLTF...',          self.file_save_gltf),
                     ('command', 'POV-Ray...',       self.file_save_pov),
                     ('command', 'STL...',           self.file_save_stl),

--- a/modules/pymol/api.py
+++ b/modules/pymol/api.py
@@ -122,6 +122,7 @@ from .querying import \
       get_distance,       \
       get_drag_object_name, \
       get_extent,         \
+      get_glb,            \
       get_gltf,           \
       get_idtf,           \
       get_modal_draw,     \

--- a/modules/pymol/exporting.py
+++ b/modules/pymol/exporting.py
@@ -1009,6 +1009,7 @@ SEE ALSO
         'png': png,
 
         # no arguments (some have a "version" argument)
+        'glb': 'pymol.querying:get_glb',
         'dae': 'pymol.querying:get_collada',
         'gltf': 'pymol.querying:get_gltf',
         'wrl': 'pymol.querying:get_vrml',

--- a/modules/pymol/exporting.py
+++ b/modules/pymol/exporting.py
@@ -809,7 +809,10 @@ NOTES
     The file format is automatically chosen if the extesion is one of
     the supported output formats: pdb, pqr, mol, sdf, pkl, pkla, mmd, out,
     dat, mmod, cif, pov, png, pse, psw, aln, fasta, obj, mtl, wrl, dae, idtf,
-    or mol2.
+    glb, gltf, or mol2.
+
+    glb and gltf export requires PyMOL to be compiled with native glTF
+    support (--json=true), see cmd.get_capabilities().
 
     If the file format is not recognized, then a PDB file is written
     by default.

--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -661,6 +661,23 @@ PYMOL API
             r = _cmd.get_collada(_self._COb,int(version))
         return r
 
+    def _get_glb_bytes(_self):
+        '''
+        Return the current scene as GLB bytes, or None if there is no
+        exportable geometry. Raises CmdException if PyMOL was built without
+        native glTF/GLB support.
+        '''
+        try:
+            get_glb_ = _cmd.get_glb
+        except AttributeError:
+            raise pymol.CmdException(
+                'not compiled with native glTF/GLB export support '
+                '(rebuild with --json=true and the nlohmann-json headers '
+                'installed)') from None
+
+        with _self.lockcm:
+            return get_glb_(_self._COb)
+
     def get_glb(filename, quiet=1, *, _self=cmd):
         '''
 DESCRIPTION
@@ -683,18 +700,20 @@ PYMOL API
     cmd.get_glb(string filename, int quiet=1)
 
         '''
-        with _self.lockcm:
-            r = _cmd.get_glb(_self._COb)
-        if r is not None:
-            with open(filename, 'wb') as handle:
-                handle.write(r)
-            if not quiet:
-                print(' Save: wrote "' + filename + '".')
-            return 1
-        else:
+        r = _get_glb_bytes(_self)
+
+        if r is None:
             if not quiet:
                 print(' Save-Error: no file written')
-            return -1
+            return DEFAULT_ERROR
+
+        with open(filename, 'wb') as handle:
+            handle.write(r)
+
+        if not quiet:
+            print(' Save: wrote "' + filename + '".')
+
+        return DEFAULT_SUCCESS
 
     def get_gltf(filename, quiet=1, *, _self=cmd):
         '''
@@ -723,13 +742,12 @@ PYMOL API
         import json
         import struct
 
-        with _self.lockcm:
-            glb = _cmd.get_glb(_self._COb)
+        glb = _get_glb_bytes(_self)
 
         if glb is None:
             if not quiet:
                 print(' Save-Error: no file written')
-            return -1
+            return DEFAULT_ERROR
 
         try:
             magic, version, total_length = struct.unpack_from('<III', glb, 0)
@@ -765,7 +783,7 @@ PYMOL API
         if not quiet:
             print(' Save: wrote "' + filename + '".')
 
-        return 1
+        return DEFAULT_SUCCESS
 
     def count_states(selection="(all)", quiet=1, *, _self=cmd):
         '''

--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -661,44 +661,111 @@ PYMOL API
             r = _cmd.get_collada(_self._COb,int(version))
         return r
 
+    def get_glb(filename, quiet=1, *, _self=cmd):
+        '''
+DESCRIPTION
+
+    "get_glb" saves a GLB (binary glTF 2.0) file representing the content
+    currently displayed.
+
+USAGE
+
+    save filename.glb
+
+ARGUMENTS
+
+    filename = string: output file path
+
+    quiet = 0 or 1: toggle verbosity {default: 1}
+
+PYMOL API
+
+    cmd.get_glb(string filename, int quiet=1)
+
+        '''
+        with _self.lockcm:
+            r = _cmd.get_glb(_self._COb)
+        if r is not None:
+            with open(filename, 'wb') as handle:
+                handle.write(r)
+            if not quiet:
+                print(' Save: wrote "' + filename + '".')
+            return 1
+        else:
+            if not quiet:
+                print(' Save-Error: no file written')
+            return -1
+
     def get_gltf(filename, quiet=1, *, _self=cmd):
         '''
 DESCRIPTION
 
-    "get_gltf" saves a gltf file representing the content
-    currently displayed.
+    "get_gltf" saves a glTF 2.0 file representing the content currently
+    displayed. Geometry data is embedded in the JSON document, so the result
+    is a single portable file.
+
+USAGE
+
+    save filename.gltf
+
+ARGUMENTS
+
+    filename = string: output file path
+
+    quiet = 0 or 1: toggle verbosity {default: 1}
 
 PYMOL API
 
-    cmd.get_gltf()
+    cmd.get_gltf(string filename, int quiet=1)
 
         '''
-        import shutil
-        exe = shutil.which('collada2gltf') or shutil.which('COLLADA2GLTF-bin')
-        if exe is None:
-            raise pymol.CmdException('could not find collada2gltf')
+        import base64
+        import json
+        import struct
 
-        # https://github.com/schrodinger/pymol-open-source/issues/107
-        _self.set('collada_geometry_mode', 1, quiet=quiet)
+        with _self.lockcm:
+            glb = _cmd.get_glb(_self._COb)
 
-        r = _self.get_collada()
+        if glb is None:
+            if not quiet:
+                print(' Save-Error: no file written')
+            return -1
 
-        # write collada file
-        with open(filename, 'w') as handle:
-            handle.write(r)
+        try:
+            magic, version, total_length = struct.unpack_from('<III', glb, 0)
+            if magic != 0x46546C67 or version != 2 or total_length != len(glb):
+                raise ValueError('invalid GLB header')
 
-        import subprocess
+            json_length, json_type = struct.unpack_from('<II', glb, 12)
+            if json_type != 0x4E4F534A:
+                raise ValueError('missing GLB JSON chunk')
 
-        result = subprocess.call([exe, '-i', filename, '-o', filename])
-                # convert collada file to gltf by using collada2gltf binary
+            json_start = 20
+            json_end = json_start + json_length
+            document = json.loads(glb[json_start:json_end])
+
+            binary_length, binary_type = struct.unpack_from('<II', glb, json_end)
+            if binary_type != 0x004E4942:
+                raise ValueError('missing GLB binary chunk')
+
+            binary_start = json_end + 8
+            binary = glb[binary_start:binary_start + binary_length]
+            buffer = document['buffers'][0]
+            binary = binary[:buffer['byteLength']]
+            buffer['uri'] = (
+                'data:application/octet-stream;base64,' +
+                base64.b64encode(binary).decode('ascii'))
+        except (KeyError, TypeError, ValueError, struct.error) as ex:
+            raise pymol.CmdException(
+                'could not convert native GLB data to glTF: %s' % ex)
+
+        with open(filename, 'w', encoding='utf-8') as handle:
+            json.dump(document, handle, separators=(',', ':'))
 
         if not quiet:
-            if result == 0:
-                print(' Save: wrote "' + filename + '".')
-            else:
-                print(' Save-Error: no file written')
+            print(' Save: wrote "' + filename + '".')
 
-        return result
+        return 1
 
     def count_states(selection="(all)", quiet=1, *, _self=cmd):
         '''

--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -795,7 +795,7 @@ SEE ALSO
                 base64.b64encode(binary).decode('ascii'))
         except (KeyError, TypeError, ValueError, struct.error) as ex:
             raise pymol.CmdException(
-                'could not convert native GLB data to glTF: %s' % ex)
+                'could not convert native GLB data to glTF: %s' % ex) from ex
 
         with open(filename, 'w', encoding='utf-8') as handle:
             json.dump(document, handle, separators=(',', ':'))

--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -706,6 +706,17 @@ PYMOL API
 
     cmd.get_glb(string filename, int quiet=1)
 
+NOTES
+
+    Requires PyMOL to be compiled with native glTF support (--json=true),
+    reported as the "gltf" capability by cmd.get_capabilities().
+
+    Text labels and ellipsoid primitives are not exported yet, they are
+    skipped with a warning.
+
+SEE ALSO
+
+    get_gltf, get_collada
         '''
         r = _get_glb_bytes(_self)
 
@@ -739,6 +750,18 @@ PYMOL API
 
     cmd.get_gltf(string filename, int quiet=1)
 
+NOTES
+
+    Requires PyMOL to be compiled with native glTF support (--json=true),
+    reported as the "gltf" capability by cmd.get_capabilities(). The
+    external collada2gltf converter is no longer used.
+
+    Text labels and ellipsoid primitives are not exported yet, they are
+    skipped with a warning.
+
+SEE ALSO
+
+    get_glb, get_collada
         '''
         import base64
         import json

--- a/modules/pymol/querying.py
+++ b/modules/pymol/querying.py
@@ -663,9 +663,9 @@ PYMOL API
 
     def _get_glb_bytes(_self):
         '''
-        Return the current scene as GLB bytes, or None if there is no
-        exportable geometry. Raises CmdException if PyMOL was built without
-        native glTF/GLB support.
+        Return the current scene as GLB bytes. Raises CmdException if PyMOL
+        was built without native glTF/GLB support, or if the scene holds no
+        exportable geometry.
         '''
         try:
             get_glb_ = _cmd.get_glb
@@ -676,7 +676,14 @@ PYMOL API
                 'installed)') from None
 
         with _self.lockcm:
-            return get_glb_(_self._COb)
+            r = get_glb_(_self._COb)
+
+        if r is None:
+            raise pymol.CmdException(
+                'no exportable geometry in the current scene',
+                'Save-Error')
+
+        return r
 
     def get_glb(filename, quiet=1, *, _self=cmd):
         '''
@@ -701,11 +708,6 @@ PYMOL API
 
         '''
         r = _get_glb_bytes(_self)
-
-        if r is None:
-            if not quiet:
-                print(' Save-Error: no file written')
-            return DEFAULT_ERROR
 
         with open(filename, 'wb') as handle:
             handle.write(r)
@@ -743,11 +745,6 @@ PYMOL API
         import struct
 
         glb = _get_glb_bytes(_self)
-
-        if glb is None:
-            if not quiet:
-                print(' Save-Error: no file written')
-            return DEFAULT_ERROR
 
         try:
             magic, version, total_length = struct.unpack_from('<III', glb, 0)

--- a/setup.py
+++ b/setup.py
@@ -639,9 +639,6 @@ if options.libxml:
     def_macros += [("_HAVE_LIBXML", None)]
     libs += ["xml2"]
 
-# sources which are only compiled for optional features
-excluded_sources = []
-
 if options.json:
     # native glTF 2.0 / GLB support (header-only dependency)
     for prefix in prefix_path:
@@ -654,8 +651,6 @@ if options.json:
             f' PREFIX_PATH={":".join(prefix_path)}'
         )
     def_macros += [("_HAVE_JSON", None)]
-else:
-    excluded_sources += [os.path.join("layer1", "GLTF.cpp")]
 
 if options.use_msgpackc == "guess":
     options.use_msgpackc = guess_msgpackc()
@@ -829,16 +824,9 @@ def get_pymol_version():
     return re.findall(r'_PyMOL_VERSION "(.*)"', open("layer0/Version.h").read())[0]
 
 
-def get_sources(subdirs, suffixes=(".c", ".cpp"), exclude=()):
-    exclude = {os.path.normpath(f) for f in exclude}
+def get_sources(subdirs, suffixes=(".c", ".cpp")):
     return sorted(
-        [
-            f
-            for d in subdirs
-            for s in suffixes
-            for f in glob.glob(d + "/*" + s)
-            if os.path.normpath(f) not in exclude
-        ]
+        [f for d in subdirs for s in suffixes for f in glob.glob(d + "/*" + s)]
     )
 
 
@@ -891,7 +879,7 @@ if WIN:
 ext_modules += [
     CMakeExtension(
         name="pymol._cmd",
-        sources=get_sources(pymol_src_dirs, exclude=excluded_sources),
+        sources=get_sources(pymol_src_dirs),
         include_dirs=inc_dirs,
         libraries=libs,
         library_dirs=lib_dirs,

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ class options:
     osx_frameworks = True
     jobs = int(os.getenv("JOBS", 0))
     libxml = True
+    json = False
     glut = False
     use_msgpackc = "guess"
     testing = False
@@ -223,6 +224,11 @@ parser.add_argument(
     "--libxml",
     type=str2bool,
     help="skip libxml2 dependency, disables COLLADA export",
+)
+parser.add_argument(
+    "--json",
+    type=str2bool,
+    help="add nlohmann-json dependency, enables glTF 2.0 and GLB export",
 )
 parser.add_argument("--use-openmp", type=str2bool, help="Use OpenMP")
 parser.add_argument(
@@ -633,6 +639,24 @@ if options.libxml:
     def_macros += [("_HAVE_LIBXML", None)]
     libs += ["xml2"]
 
+# sources which are only compiled for optional features
+excluded_sources = []
+
+if options.json:
+    # native glTF 2.0 / GLB support (header-only dependency)
+    for prefix in prefix_path:
+        if os.path.exists(os.path.join(prefix, "include", "nlohmann", "json.hpp")):
+            break
+    else:
+        raise LookupError(
+            "nlohmann-json headers not found, required by --json=true"
+            " (glTF 2.0 and GLB export)."
+            f' PREFIX_PATH={":".join(prefix_path)}'
+        )
+    def_macros += [("_HAVE_JSON", None)]
+else:
+    excluded_sources += [os.path.join("layer1", "GLTF.cpp")]
+
 if options.use_msgpackc == "guess":
     options.use_msgpackc = guess_msgpackc()
 
@@ -805,9 +829,16 @@ def get_pymol_version():
     return re.findall(r'_PyMOL_VERSION "(.*)"', open("layer0/Version.h").read())[0]
 
 
-def get_sources(subdirs, suffixes=(".c", ".cpp")):
+def get_sources(subdirs, suffixes=(".c", ".cpp"), exclude=()):
+    exclude = {os.path.normpath(f) for f in exclude}
     return sorted(
-        [f for d in subdirs for s in suffixes for f in glob.glob(d + "/*" + s)]
+        [
+            f
+            for d in subdirs
+            for s in suffixes
+            for f in glob.glob(d + "/*" + s)
+            if os.path.normpath(f) not in exclude
+        ]
     )
 
 
@@ -860,7 +891,7 @@ if WIN:
 ext_modules += [
     CMakeExtension(
         name="pymol._cmd",
-        sources=get_sources(pymol_src_dirs),
+        sources=get_sources(pymol_src_dirs, exclude=excluded_sources),
         include_dirs=inc_dirs,
         libraries=libs,
         library_dirs=lib_dirs,

--- a/testing/tests/api/exporting.py
+++ b/testing/tests/api/exporting.py
@@ -413,12 +413,14 @@ class TestExporting(testing.PyMOLTestCase):
         self.assertEqual(cmd.get_names(), ['m1'])
 
     @testing.requires_version('2.4')
+    @unittest.skipUnless('gltf' in pymol.get_capabilities(),
+                         'no native glTF support')
     def testglTF(self):
         '''glTF export'''
         cmd.fragment('gly')
 
         with testing.mktemp('.gltf') as filename:
-            self.assertEqual(cmd.save(filename), 0)
+            self.assertIsNone(cmd.save(filename))
             cmd.delete('*')
 
     def testSaveAln(self):

--- a/testing/tests/api/test_exporting.py
+++ b/testing/tests/api/test_exporting.py
@@ -4,6 +4,9 @@ import os
 import struct
 import tempfile
 
+import pytest
+
+import pymol
 from pymol import cmd
 from pymol import test_utils
 
@@ -340,16 +343,22 @@ def test_glb_export_transparent():
 
 @test_utils.requires_version("3.2")
 @requires_gltf
-def test_glb_export_empty():
-    """Test GLB export with no exportable geometry produces no file"""
+@pytest.mark.parametrize("suffix", [".glb", ".gltf"])
+def test_glb_export_empty(suffix):
+    """Export with no exportable geometry raises and writes no file"""
     cmd.fragment("ala")
     cmd.show_as("cartoon")  # too few residues for cartoon
 
-    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
-        glb_file = f.name
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+        out_file = f.name
 
     # Remove the temp file so we can check if save creates one
-    os.unlink(glb_file)
+    os.unlink(out_file)
 
-    cmd.save(glb_file)
-    assert not os.path.exists(glb_file)
+    try:
+        with pytest.raises(pymol.CmdException):
+            cmd.save(out_file)
+        assert not os.path.exists(out_file)
+    finally:
+        if os.path.exists(out_file):
+            os.unlink(out_file)

--- a/testing/tests/api/test_exporting.py
+++ b/testing/tests/api/test_exporting.py
@@ -87,6 +87,17 @@ def _read_vertex_colors(gltf, bin_data, mesh_index=0):
     return list(zip(values[0::3], values[1::3], values[2::3]))
 
 
+def _read_vertex_normals(gltf, bin_data, mesh_index=0):
+    """Return a mesh's NORMAL values as a list of (x, y, z) tuples."""
+    prim = gltf['meshes'][mesh_index]['primitives'][0]
+    normal_acc = gltf['accessors'][prim['attributes']['NORMAL']]
+    normal_view = gltf['bufferViews'][normal_acc['bufferView']]
+    offset = normal_view.get('byteOffset', 0) + normal_acc.get('byteOffset', 0)
+    values = struct.unpack_from(
+        '<%df' % (normal_acc['count'] * 3), bin_data, offset)
+    return list(zip(values[0::3], values[1::3], values[2::3]))
+
+
 def _parse_glb(filepath):
     """Parse a GLB file and return (gltf_json, bin_data)."""
     with open(filepath, 'rb') as f:
@@ -282,12 +293,18 @@ def test_glb_export_cartoon():
         cmd.save(glb_file)
         assert os.path.getsize(glb_file) > 0
 
-        gltf, _ = _parse_glb(glb_file)
+        gltf, bin_data = _parse_glb(glb_file)
         assert len(gltf['meshes']) >= 1
 
         prim = gltf['meshes'][0]['primitives'][0]
         pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
         assert pos_acc['count'] > 100  # cartoon should have many vertices
+
+        normals = _read_vertex_normals(gltf, bin_data)
+        assert len(normals) == pos_acc['count']
+        for normal in normals:
+            length_squared = sum(component * component for component in normal)
+            assert abs(length_squared - 1.0) < 1e-5, normal
     finally:
         if os.path.exists(glb_file):
             os.unlink(glb_file)

--- a/testing/tests/api/test_exporting.py
+++ b/testing/tests/api/test_exporting.py
@@ -7,6 +7,9 @@ import tempfile
 from pymol import cmd
 from pymol import test_utils
 
+requires_gltf = test_utils.requires_capability(
+    "gltf", "Requires PyMOL built with --json=true (native glTF/GLB export)")
+
 
 @test_utils.requires_version("3.2")
 def test_bcif_export():
@@ -62,6 +65,28 @@ def test_bcif_export_multi_object():
             os.unlink(bcif_file)
 
 
+def _srgb_to_linear(c):
+    """Reference implementation of the glTF sRGB to linear transfer."""
+    if c <= 0.0:
+        return 0.0
+    if c >= 1.0:
+        return 1.0
+    if c <= 0.04045:
+        return c / 12.92
+    return ((c + 0.055) / 1.055) ** 2.4
+
+
+def _read_vertex_colors(gltf, bin_data, mesh_index=0):
+    """Return a mesh's COLOR_0 values as a list of (r, g, b) tuples."""
+    prim = gltf['meshes'][mesh_index]['primitives'][0]
+    color_acc = gltf['accessors'][prim['attributes']['COLOR_0']]
+    color_view = gltf['bufferViews'][color_acc['bufferView']]
+    offset = color_view.get('byteOffset', 0) + color_acc.get('byteOffset', 0)
+    values = struct.unpack_from(
+        '<%df' % (color_acc['count'] * 3), bin_data, offset)
+    return list(zip(values[0::3], values[1::3], values[2::3]))
+
+
 def _parse_glb(filepath):
     """Parse a GLB file and return (gltf_json, bin_data)."""
     with open(filepath, 'rb') as f:
@@ -84,6 +109,7 @@ def _parse_glb(filepath):
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_sticks():
     """Test GLB export with stick representation"""
     cmd.fragment("ala")
@@ -108,6 +134,9 @@ def test_glb_export_sticks():
         assert len(gltf['buffers']) == 1
         assert len(bin_data) > 0
 
+        # PyMOL renders without back-face culling
+        assert all(mat['doubleSided'] for mat in gltf['materials'])
+
         # Check mesh has required attributes
         prim = gltf['meshes'][0]['primitives'][0]
         assert 'POSITION' in prim['attributes']
@@ -129,6 +158,7 @@ def test_glb_export_sticks():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_gltf_export_sticks():
     """Test native, self-contained glTF 2.0 export"""
     cmd.fragment("ala")
@@ -157,6 +187,7 @@ def test_gltf_export_sticks():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_spheres():
     """Test GLB export API with sphere representation and vertex colors"""
     cmd.pseudoatom("atoms", pos=[0.0, 0.0, 0.0], color="red")
@@ -177,13 +208,7 @@ def test_glb_export_spheres():
         pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
         assert pos_acc['count'] > 0
 
-        color_acc = gltf['accessors'][prim['attributes']['COLOR_0']]
-        color_view = gltf['bufferViews'][color_acc['bufferView']]
-        color_offset = color_view.get('byteOffset', 0)
-        color_offset += color_acc.get('byteOffset', 0)
-        colors = struct.unpack_from(
-            '<%df' % (color_acc['count'] * 3), bin_data, color_offset)
-        colors = list(zip(colors[0::3], colors[1::3], colors[2::3]))
+        colors = _read_vertex_colors(gltf, bin_data)
         assert any(r > 0.99 and g < 0.01 and b < 0.01 for r, g, b in colors)
         assert any(r < 0.01 and g < 0.01 and b > 0.99 for r, g, b in colors)
     finally:
@@ -192,6 +217,38 @@ def test_glb_export_spheres():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
+def test_glb_export_midtone_color_is_linear():
+    """Mid-tone colors are converted from PyMOL display space to linear"""
+    cmd.pseudoatom("atoms", pos=[0.0, 0.0, 0.0], color="grey50")
+    cmd.show_as("spheres")
+
+    display = cmd.get_color_tuple("grey50")
+    expected = tuple(_srgb_to_linear(c) for c in display)
+
+    # only meaningful if the color actually is a mid-tone
+    assert all(0.01 < c < 0.99 for c in display)
+    assert all(abs(e - d) > 0.05 for e, d in zip(expected, display))
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.save(glb_file)
+        gltf, bin_data = _parse_glb(glb_file)
+
+        colors = _read_vertex_colors(gltf, bin_data)
+        assert colors
+        for color in colors:
+            assert all(abs(c - e) < 1e-5 for c, e in zip(color, expected)), \
+                f"{color} != {expected}"
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_surface():
     """Test GLB export with surface representation"""
     cmd.fragment("gly")
@@ -212,6 +269,7 @@ def test_glb_export_surface():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_cartoon():
     """Test GLB export with cartoon representation (needs enough residues)"""
     cmd.load(test_utils.datafile('1bna.cif'))
@@ -236,6 +294,7 @@ def test_glb_export_cartoon():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_transparent():
     """Test GLB export with transparency creates BLEND material"""
     cmd.fragment("ala")
@@ -263,6 +322,7 @@ def test_glb_export_transparent():
 
 
 @test_utils.requires_version("3.2")
+@requires_gltf
 def test_glb_export_empty():
     """Test GLB export with no exportable geometry produces no file"""
     cmd.fragment("ala")

--- a/testing/tests/api/test_exporting.py
+++ b/testing/tests/api/test_exporting.py
@@ -1,7 +1,11 @@
+import base64
+import json
 import os
+import struct
+import tempfile
+
 from pymol import cmd
 from pymol import test_utils
-import tempfile
 
 
 @test_utils.requires_version("3.2")
@@ -56,3 +60,219 @@ def test_bcif_export_multi_object():
     finally:
         if os.path.exists(bcif_file):
             os.unlink(bcif_file)
+
+
+def _parse_glb(filepath):
+    """Parse a GLB file and return (gltf_json, bin_data)."""
+    with open(filepath, 'rb') as f:
+        data = f.read()
+    magic, version, length = struct.unpack_from('<III', data, 0)
+    assert magic == 0x46546C67, f"Bad GLB magic: {hex(magic)}"
+    assert version == 2
+    assert length == len(data)
+
+    json_len, json_type = struct.unpack_from('<II', data, 12)
+    assert json_type == 0x4E4F534A  # "JSON"
+    gltf = json.loads(data[20:20 + json_len])
+
+    bin_offset = 20 + json_len
+    bin_len, bin_type = struct.unpack_from('<II', data, bin_offset)
+    assert bin_type == 0x004E4942  # "BIN\0"
+    bin_data = data[bin_offset + 8:bin_offset + 8 + bin_len]
+
+    return gltf, bin_data
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_sticks():
+    """Test GLB export with stick representation"""
+    cmd.fragment("ala")
+    cmd.show_as("sticks")
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.save(glb_file)
+        assert os.path.exists(glb_file)
+        assert os.path.getsize(glb_file) > 0
+
+        gltf, bin_data = _parse_glb(glb_file)
+
+        # Validate glTF structure
+        assert gltf['asset']['version'] == '2.0'
+        assert 'PyMOL' in gltf['asset']['generator']
+        assert len(gltf['scenes']) == 1
+        assert len(gltf['meshes']) >= 1
+        assert len(gltf['materials']) >= 1
+        assert len(gltf['buffers']) == 1
+        assert len(bin_data) > 0
+
+        # Check mesh has required attributes
+        prim = gltf['meshes'][0]['primitives'][0]
+        assert 'POSITION' in prim['attributes']
+        assert 'NORMAL' in prim['attributes']
+        assert 'COLOR_0' in prim['attributes']
+        assert 'indices' in prim
+        assert prim['mode'] == 4  # TRIANGLES
+
+        # Check accessor types
+        pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
+        assert pos_acc['type'] == 'VEC3'
+        assert pos_acc['componentType'] == 5126  # FLOAT
+        assert pos_acc['count'] > 0
+        assert 'min' in pos_acc
+        assert 'max' in pos_acc
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+def test_gltf_export_sticks():
+    """Test native, self-contained glTF 2.0 export"""
+    cmd.fragment("ala")
+    cmd.show_as("sticks")
+
+    with tempfile.NamedTemporaryFile(suffix='.gltf', delete=False) as f:
+        gltf_file = f.name
+
+    try:
+        cmd.save(gltf_file)
+
+        with open(gltf_file, encoding='utf-8') as handle:
+            gltf = json.load(handle)
+
+        assert gltf['asset']['version'] == '2.0'
+        assert len(gltf['meshes']) >= 1
+
+        buffer = gltf['buffers'][0]
+        prefix = 'data:application/octet-stream;base64,'
+        assert buffer['uri'].startswith(prefix)
+        binary = base64.b64decode(buffer['uri'][len(prefix):])
+        assert len(binary) == buffer['byteLength']
+    finally:
+        if os.path.exists(gltf_file):
+            os.unlink(gltf_file)
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_spheres():
+    """Test GLB export API with sphere representation and vertex colors"""
+    cmd.pseudoatom("atoms", pos=[0.0, 0.0, 0.0], color="red")
+    cmd.pseudoatom("atoms", pos=[4.0, 0.0, 0.0], color="blue")
+    cmd.show_as("spheres")
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.get_glb(glb_file)
+        assert os.path.getsize(glb_file) > 0
+
+        gltf, bin_data = _parse_glb(glb_file)
+        assert len(gltf['meshes']) >= 1
+
+        prim = gltf['meshes'][0]['primitives'][0]
+        pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
+        assert pos_acc['count'] > 0
+
+        color_acc = gltf['accessors'][prim['attributes']['COLOR_0']]
+        color_view = gltf['bufferViews'][color_acc['bufferView']]
+        color_offset = color_view.get('byteOffset', 0)
+        color_offset += color_acc.get('byteOffset', 0)
+        colors = struct.unpack_from(
+            '<%df' % (color_acc['count'] * 3), bin_data, color_offset)
+        colors = list(zip(colors[0::3], colors[1::3], colors[2::3]))
+        assert any(r > 0.99 and g < 0.01 and b < 0.01 for r, g, b in colors)
+        assert any(r < 0.01 and g < 0.01 and b > 0.99 for r, g, b in colors)
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_surface():
+    """Test GLB export with surface representation"""
+    cmd.fragment("gly")
+    cmd.show_as("surface")
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.save(glb_file)
+        gltf, _ = _parse_glb(glb_file)
+        prim = gltf['meshes'][0]['primitives'][0]
+        pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
+        assert pos_acc['count'] > 0
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_cartoon():
+    """Test GLB export with cartoon representation (needs enough residues)"""
+    cmd.load(test_utils.datafile('1bna.cif'))
+    cmd.show_as("cartoon")
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.save(glb_file)
+        assert os.path.getsize(glb_file) > 0
+
+        gltf, _ = _parse_glb(glb_file)
+        assert len(gltf['meshes']) >= 1
+
+        prim = gltf['meshes'][0]['primitives'][0]
+        pos_acc = gltf['accessors'][prim['attributes']['POSITION']]
+        assert pos_acc['count'] > 100  # cartoon should have many vertices
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_transparent():
+    """Test GLB export with transparency creates BLEND material"""
+    cmd.fragment("ala")
+    cmd.show_as("spheres")
+    cmd.set("sphere_transparency", 0.5)
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    try:
+        cmd.save(glb_file)
+        assert os.path.getsize(glb_file) > 0
+
+        gltf, _ = _parse_glb(glb_file)
+
+        # Should have a material with BLEND alpha mode
+        has_blend = any(
+            mat.get('alphaMode') == 'BLEND'
+            for mat in gltf['materials']
+        )
+        assert has_blend, "Transparent geometry should produce BLEND material"
+    finally:
+        if os.path.exists(glb_file):
+            os.unlink(glb_file)
+
+
+@test_utils.requires_version("3.2")
+def test_glb_export_empty():
+    """Test GLB export with no exportable geometry produces no file"""
+    cmd.fragment("ala")
+    cmd.show_as("cartoon")  # too few residues for cartoon
+
+    with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as f:
+        glb_file = f.name
+
+    # Remove the temp file so we can check if save creates one
+    os.unlink(glb_file)
+
+    cmd.save(glb_file)
+    assert not os.path.exists(glb_file)

--- a/testing/tests/helpers/test_utils.py
+++ b/testing/tests/helpers/test_utils.py
@@ -4,6 +4,7 @@ import numpy
 from pathlib import Path
 import pytest
 
+import pymol
 from pymol import cmd
 
 
@@ -129,5 +130,18 @@ def requires_version(version, reason=None):
         return pytest.mark.skipif(
             not compatible_with(version),
             reason=reason or f"Requires PyMOL {version}"
+        )(test_func)
+    return decorator
+
+
+def requires_capability(capability, reason=None):
+    """
+    Skip a test unless PyMOL was compiled with the given optional feature,
+    as reported by pymol.get_capabilities().
+    """
+    def decorator(test_func):
+        return pytest.mark.skipif(
+            capability not in pymol.get_capabilities(),
+            reason=reason or f"Requires PyMOL capability {capability!r}"
         )(test_func)
     return decorator


### PR DESCRIPTION
## Summary

Implements the glTF/GLB portion of #497 by adding native glTF 2.0 and binary GLB export without the external COLLADA2GLTF conversion step. The exporter preserves geometry scale, vertex colors, normals, and transparency for sticks, spheres, cartoons, and surfaces.

Export is opt-in at build time with `--json=true` and requires nlohmann-json. Text labels and ellipsoids remain unsupported in this first pass.

## Testing

- Added coverage for GLB containers, self-contained glTF, representations, colors, normals, transparency, and empty scenes.
- Validated exported files with the Khronos glTF Validator and three.js.
- Verified builds with and without `--json=true`.
- All CI checks pass.
